### PR TITLE
Memory mapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 repository = "https://github.com/jltsiren/simple-sds"
 
 [features]
-bench = ["getopts", "libc", "rand"]
+bench = ["getopts", "rand"]
 
 [dependencies]
 getopts = { version = "0.2", optional = true }
-libc = { version = "0.2", optional = true }
+libc = "0.2"
 rand = { version = "0.7", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
 
 ### Bitvectors
 
+* Multiset support for `SparseVector`.
 * `select_zero()` for `SparseVector`?
 * Versions of `predecessor()` and `successor()` that return values instead of iterators?
 * Slice-like functionality based on iterators?

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
 ### Integer vectors
 
 * `RawVector`: A bit array that supports reading, writing, and appending 1-64 bits at a time. Implemented on top of `Vec<u64>`.
-* `RawVectorWriter`: An append-only version of `RawVector` that writes the structure directly to a file.
+  * `RawVectorWriter`: An append-only version of `RawVector` that writes the structure directly to a file.
+  * `RawVectorMapper`: An immutable memory-mapped `RawVector`.
 * `IntVector`: A bit-packed vector of fixed-width integers implemented on top of `RawVector`. Like `sdsl::int_vector` but also supports stack functionality.
-* `IntVectorWriter`: An append-only version of `IntVector` that writes the structure directly to a file. Like a subset of `sdsl::int_vector_buffer`.
+  * `IntVectorWriter`: An append-only version of `IntVector` that writes the structure directly to a file. Like a subset of `sdsl::int_vector_buffer`.
+  * `IntVectorMapper`: An immutable memory-mapped `IntVector`.
 
 ### Bitvectors
 
@@ -29,7 +31,6 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
 ### Integer vectors
 
 * `TupleVector`: A bit-packed vector of tuples of unsigned integers, with a fixed width for each field in the tuple. Implemented on top of `RawVector`.
-* Memory-mapped versions of all vectors.
 * Mutable memory-mapped vectors.
 
 ### Bitvectors

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
 
 * `TupleVector`: A bit-packed vector of tuples of unsigned integers, with a fixed width for each field in the tuple. Implemented on top of `RawVector`.
 * Memory-mapped versions of all vectors.
+* Mutable memory-mapped vectors.
 
 ### Bitvectors
 

--- a/README.md
+++ b/README.md
@@ -41,5 +41,6 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
 
 * The included `.cargo/config.toml` sets the target CPU to `native`.
 * This crate is designed for the x86_64 architecture with the BMI2 instruction set (Intel Haswell / AMD Excavator or later).
+* The crate only compiles on a Unix-like OS because it uses `mmap()`.
 * Things may not work if the system is not little-endian or if `usize` is not 64-bit.
 * Some operations may be slow without the POPCNT, LZCNT, TZCNT, and PDEP instructions.

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -633,12 +633,12 @@ impl Serialize for BitVector {
         Ok(result)
     }
 
-    fn size_in_bytes(&self) -> usize {
-        self.ones.size_in_bytes() +
-        self.data.size_in_bytes() +
-        self.rank.size_in_bytes() +
-        self.select.size_in_bytes() +
-        self.select_zero.size_in_bytes()
+    fn size_in_elements(&self) -> usize {
+        self.ones.size_in_elements() +
+        self.data.size_in_elements() +
+        self.rank.size_in_elements() +
+        self.select.size_in_elements() +
+        self.select_zero.size_in_elements()
     }
 }
 

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -33,6 +33,11 @@ mod tests;
 /// See [`rank_support`] and [`select_support`] for algorithmic details on rank/select queries.
 /// Predecessor and successor queries depend on both support structures.
 ///
+/// The support structures are serialized as [`Option`] and hence may be missing.
+/// When `BitVector` is used as a part of another structure, the user should enable the required support structures after loading.
+/// This makes interoperation with other libraries easier, as the other library only has to serialize the bitvector itself.
+/// Enabling support structures is fast if they were present in the serialized data.
+///
 /// # Examples
 ///
 /// ```

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -23,7 +23,7 @@ mod tests;
 /// This structure contains [`RawVector`], which is in turn contains [`Vec`].
 /// Because most queries require separate support structures, the bit array itself is immutable.
 /// Conversions between `BitVector` and [`RawVector`] are possible using the [`From`] trait.
-/// The maximum length of the vector is approximately `usize::MAX` bits.
+/// The maximum length of the vector is approximately [`usize::MAX`] bits.
 ///
 /// `BitVector` implements the following `simple_sds` traits:
 /// * Basic functionality: [`BitVec`]
@@ -106,7 +106,7 @@ pub struct BitVector {
 
 /// A read-only iterator over [`BitVector`].
 ///
-/// The type of `Item` is `bool`.
+/// The type of `Item` is [`bool`].
 ///
 /// # Examples
 ///
@@ -331,7 +331,7 @@ impl Transformation for Complement {
 
 /// An iterator over the set bits in an implicitly transformed [`BitVector`].
 ///
-/// The type of `Item` is `(usize, usize)`.
+/// The type of `Item` is `(`[`usize`]`, `[`usize`]`)`.
 /// This can be interpreted as:
 ///
 /// * `(index, value)` or `(i, select(i))` in the integer array; or

--- a/src/bit_vector/rank_support.rs
+++ b/src/bit_vector/rank_support.rs
@@ -182,8 +182,8 @@ impl Serialize for RankSupport {
         })
     }
 
-    fn size_in_bytes(&self) -> usize {
-        self.samples.size_in_bytes()
+    fn size_in_elements(&self) -> usize {
+        self.samples.size_in_elements()
     }
 }
 

--- a/src/bit_vector/select_support.rs
+++ b/src/bit_vector/select_support.rs
@@ -277,8 +277,8 @@ impl<T: Transformation> Serialize for SelectSupport<T> {
         })
     }
 
-    fn size_in_bytes(&self) -> usize {
-        self.samples.size_in_bytes() + self.long.size_in_bytes() + self.short.size_in_bytes()
+    fn size_in_elements(&self) -> usize {
+        self.samples.size_in_elements() + self.long.size_in_elements() + self.short.size_in_elements()
     }
 }
 

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -494,6 +494,7 @@ mod tests {
         assert_eq!(mem::size_of::<usize>(), 8, "Things may not work if usize is not 64 bits");
         assert!(cfg!(target_endian = "little"), "Things may not work on a big-endian system");
         assert!(cfg!(target_arch = "x86_64"), "Things may not work on architectures other than x86_64");
+        assert!(cfg!(unix), "Memory mapping requires Unix-like OS");
 
         assert!(cfg!(target_feature = "popcnt"), "Performance may be worse without the POPCNT instruction");
         assert!(cfg!(target_feature = "lzcnt"), "Performance may be worse without the LZCNT instruction");

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -6,13 +6,13 @@ use std::ops::{Index, IndexMut};
 
 //-----------------------------------------------------------------------------
 
-/// Number of bits in `u64`.
+/// Number of bits in [`u64`].
 pub const WORD_BITS: usize = 64;
 
 // Bit shift for transforming a bit offset into an array index.
 const INDEX_SHIFT: usize = 6;
 
-// Bit mask for transforming a bit offset into an offset in `u64`.
+// Bit mask for transforming a bit offset into an offset in [`u64`].
 const OFFSET_MASK: usize = 0b111111;
 
 //-----------------------------------------------------------------------------
@@ -189,7 +189,7 @@ pub unsafe fn select(n: u64, rank: usize) -> usize {
 
 //-----------------------------------------------------------------------------
 
-/// Returns the number of bits that can be stored in `n` integers of type `u64`.
+/// Returns the number of bits that can be stored in `n` integers of type [`u64`].
 ///
 /// # Examples
 ///
@@ -207,7 +207,7 @@ pub fn words_to_bits(n: usize) -> usize {
     n * WORD_BITS
 }
 
-/// Returns the number of integers of type `u64` required to store `n` bits.
+/// Returns the number of integers of type [`u64`] required to store `n` bits.
 ///
 /// # Examples
 ///
@@ -249,7 +249,7 @@ pub fn round_up_to_word_size(n: usize) -> usize {
     }
 }
 
-/// Returns a `u64` value consisting entirely of bit `value`.
+/// Returns a [`u64`] value consisting entirely of bit `value`.
 ///
 /// # Examples
 ///
@@ -267,7 +267,7 @@ pub fn filler_value(value: bool) -> u64 {
     }
 }
 
-/// Splits a bit offset into an index in an array of `u64` and an offset within the integer.
+/// Splits a bit offset into an index in an array of [`u64`] and an offset within the integer.
 ///
 /// # Examples
 ///
@@ -281,7 +281,7 @@ pub fn split_offset(bit_offset: usize) -> (usize, usize) {
     (bit_offset >> INDEX_SHIFT, bit_offset & OFFSET_MASK)
 }
 
-/// Combines an index in an array of `u64` and an offset within the integer into a bit offset.
+/// Combines an index in an array of [`u64`] and an offset within the integer into a bit offset.
 ///
 /// # Arguments
 ///
@@ -298,7 +298,7 @@ pub fn split_offset(bit_offset: usize) -> (usize, usize) {
 ///
 /// # Panics
 ///
-/// May panic if the result would be greater than `usize::MAX`.
+/// May panic if the result would be greater than [`usize::MAX`].
 #[inline]
 pub fn bit_offset(index: usize, offset: usize) -> usize {
     (index << INDEX_SHIFT) + offset
@@ -306,7 +306,7 @@ pub fn bit_offset(index: usize, offset: usize) -> usize {
 
 //-----------------------------------------------------------------------------
 
-/// Writes an integer into a bit array implemented as an array of `u64` values.
+/// Writes an integer into a bit array implemented as an array of [`u64`] values.
 ///
 /// Behavior is undefined if `width > 64`.
 ///
@@ -347,7 +347,7 @@ pub unsafe fn write_int<T: IndexMut<usize, Output = u64>>(array: &mut T, bit_off
     }
 }
 
-/// Reads an integer from a bit array implemented as an array of `u64` values.
+/// Reads an integer from a bit array implemented as an array of [`u64`] values.
 ///
 /// Behavior is undefined if `width > 64`.
 ///

--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -19,11 +19,11 @@ mod tests;
 /// A contiguous growable bit-packed array of fixed-width integers.
 ///
 /// This structure contains [`RawVector`], which is in turn contains [`Vec`].
-/// Each element consists of the lowest 1 to 64 bits of a `u64` value, as specified by parameter `width`.
+/// Each element consists of the lowest 1 to 64 bits of a [`u64`] value, as specified by parameter `width`.
 /// The maximum length of the vector is `usize::MAX / width` elements.
 ///
 /// A default constructed `IntVector` has `width == 64`.
-/// `IntVector` can be built from an iterator over `u8`, `u16`, `u32`, `u64`, or `usize` values.
+/// `IntVector` can be built from an iterator over [`u8`], [`u16`], [`u32`], [`u64`], or [`usize`] values.
 ///
 /// `IntVector` implements the following `simple_sds` traits:
 /// * Basic functionality: [`Element`], [`Resize`], [`Pack`]
@@ -43,7 +43,7 @@ pub struct IntVector {
 impl IntVector {
     /// Creates an empty vector with specified width.
     /// 
-    /// Returns `Err` if the width is invalid.
+    /// Returns [`Err`] if the width is invalid.
     ///
     /// # Examples
     ///
@@ -70,7 +70,7 @@ impl IntVector {
 
     /// Creates an initialized vector of specified length and width.
     /// 
-    /// Returns `Err` if the width is invalid.
+    /// Returns [`Err`] if the width is invalid.
     ///
     /// # Arguments
     ///
@@ -112,7 +112,7 @@ impl IntVector {
 
     /// Creates an empty vector with enough capacity for at least the specified number of elements of specified width.
     ///
-    /// Returns `Err` if the width is invalid.
+    /// Returns [`Err`] if the width is invalid.
     ///
     /// # Arguments
     ///
@@ -328,7 +328,7 @@ impl From<IntVector> for RawVector {
 
 /// A read-only iterator over [`IntVector`].
 ///
-/// The type of `Item` is `u64`.
+/// The type of `Item` is [`u64`].
 ///
 /// # Examples
 ///
@@ -389,7 +389,7 @@ impl<'a> FusedIterator for Iter<'a> {}
 
 /// [`IntVector`] transformed into an iterator.
 ///
-/// The type of `Item` is `u64`.
+/// The type of `Item` is [`u64`].
 ///
 /// # Examples
 ///

--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -445,6 +445,7 @@ impl IntoIterator for IntVector {
 
 //-----------------------------------------------------------------------------
 
+// FIXME example
 /// A buffered file writer compatible with the serialization format of [`IntVector`].
 ///
 /// When the writer goes out of scope, the internal buffer is flushed, the file is closed, and all errors are ignored.
@@ -472,12 +473,12 @@ impl IntVectorWriter {
     /// use simple_sds::int_vector::IntVectorWriter;
     /// use simple_sds::ops::Element;
     /// use simple_sds::serialize;
-    /// use std::{fs, mem};
+    /// use std::fs;
     ///
     /// let filename = serialize::temp_file_name("int-vector-writer-new");
     /// let mut v = IntVectorWriter::new(&filename, 13).unwrap();
     /// assert!(v.is_empty());
-    /// mem::drop(v);
+    /// drop(v);
     /// fs::remove_file(&filename).unwrap();
     /// ```
     ///
@@ -519,12 +520,12 @@ impl IntVectorWriter {
     /// use simple_sds::int_vector::IntVectorWriter;
     /// use simple_sds::ops::Element;
     /// use simple_sds::serialize;
-    /// use std::{fs, mem};
+    /// use std::fs;
     ///
     /// let filename = serialize::temp_file_name("int-vector-writer-with-buf-len");
     /// let mut v = IntVectorWriter::with_buf_len(&filename, 13, 1024).unwrap();
     /// assert!(v.is_empty());
-    /// mem::drop(v);
+    /// drop(v);
     /// fs::remove_file(&filename).unwrap();
     /// ```
     ///

--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -294,8 +294,8 @@ impl Serialize for IntVector {
         })
     }
 
-    fn size_in_bytes(&self) -> usize {
-        self.len.size_in_bytes() + self.width.size_in_bytes() + self.data.size_in_bytes()
+    fn size_in_elements(&self) -> usize {
+        self.len.size_in_elements() + self.width.size_in_elements() + self.data.size_in_elements()
     }
 }
 

--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -608,7 +608,6 @@ impl Drop for IntVectorWriter {
 
 //-----------------------------------------------------------------------------
 
-// FIXME tests
 /// An immutable memory-mapped [`IntVector`].
 ///
 /// This is compatible with the serialization format of [`IntVector`].
@@ -746,7 +745,6 @@ impl<'a> AsRef<RawVectorMapper<'a>> for IntVectorMapper<'a> {
 
 //-----------------------------------------------------------------------------
 
-// FIXME tests
 /// A read-only iterator over [`IntVectorMapper`].
 ///
 /// The type of `Item` is [`u64`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! # Notes
 //!
 //! * This crate is designed for the x86_64 architecture with the BMI2 instruction set (Intel Haswell / AMD Excavator or later).
+//! * The crate only works on a Unix-like OS because it uses `mmap()`.
 //! * Things may not work if the system is not little-endian or if `usize` is not 64-bit.
 //! * Some operations may be slow without the POPCNT, LZCNT, TZCNT, and PDEP instructions.
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -295,7 +295,7 @@ pub trait Push: Element {
 /// See [`Push`] for an example.
 pub trait Pop: Element {
     /// Removes and returns the last element from the vector.
-    /// Returns `None` if there are no more elements in the vector.
+    /// Returns [`None`] if there are no more elements in the vector.
     fn pop(&mut self) -> Option<<Self as Element>::Item>;
 }
 
@@ -799,7 +799,7 @@ pub trait Select<'a>: BitVec<'a> {
     /// The iterator may also panic for the same reason.
     fn one_iter(&'a self) -> Self::OneIter;
 
-    /// Returns the specified value in the integer array or `Err` if no such value exists.
+    /// Returns the specified value in the integer array or [`Err`] if no such value exists.
     ///
     /// In the bit array interpretation, the return value is an index `i` such that `self.get(i) == true` and `self.rank(i) == rank`.
     /// This trait uses 0-based indexing, while the [SDSL](https://github.com/simongog/sdsl-lite) select uses 1-based indexing.
@@ -812,7 +812,7 @@ pub trait Select<'a>: BitVec<'a> {
 
     /// Returns an iterator at the specified rank in the integer array.
     ///
-    /// The iterator will return `None` if the rank is out of bounds.
+    /// The iterator will return [`None`] if the rank is out of bounds.
     /// In the bit array interpretation, the iterator points to the set bit of the specified rank.
     /// This means a bit array index `i` such that `self.get(i) == true` and `self.rank(i) == rank`.
     /// This trait uses 0-based indexing, while the [SDSL](https://github.com/simongog/sdsl-lite) select uses 1-based indexing.
@@ -859,7 +859,7 @@ pub trait SelectZero<'a>: BitVec<'a> {
     /// The iterator may also panic for the same reason.
     fn zero_iter(&'a self) -> Self::ZeroIter;
 
-    /// Returns the specified value in the complement of the integer array or `Err` if no such value exists.
+    /// Returns the specified value in the complement of the integer array or [`Err`] if no such value exists.
     ///
     /// In the bit array interpretation, the return value is an index `i` such that `self.get(i) == false` and `self.rank_zero(i) == rank`.
     /// This trait uses 0-based indexing, while the [SDSL](https://github.com/simongog/sdsl-lite) select uses 1-based indexing.
@@ -872,7 +872,7 @@ pub trait SelectZero<'a>: BitVec<'a> {
 
     /// Returns an iterator at the specified rank in the complement of the integer array.
     ///
-    /// The iterator will return `None` if the rank is out of bounds.
+    /// The iterator will return [`None`] if the rank is out of bounds.
     /// In the bit array interpretation, the iterator points to an index `i` such that `self.get(i) == false` and `self.rank_zero(i) == rank`.
     /// This trait uses 0-based indexing, while the [SDSL](https://github.com/simongog/sdsl-lite) select uses 1-based indexing.
     ///
@@ -922,7 +922,7 @@ pub trait PredSucc<'a>: BitVec<'a> {
 
     /// Returns an iterator at the smallest `v >= value` in the integer array.
     ///
-    /// The iterator will return `None` if no such value exists.
+    /// The iterator will return [`None`] if no such value exists.
     /// In the bit array interpretation, the iterator points to the smallest `i >= value` such that `self.get(i) == true`.
     ///
     /// # Panics

--- a/src/raw_vector.rs
+++ b/src/raw_vector.rs
@@ -258,11 +258,11 @@ pub trait PushRaw {
 /// ```
 pub trait PopRaw {
     /// Removes and returns the last bit from the container.
-    /// Returns `None` the container does not have more bits.
+    /// Returns [`None`] the container does not have more bits.
     fn pop_bit(&mut self) -> Option<bool>;
 
     /// Removes and returns the last `width` bits from the container as an integer.
-    /// Returns `None` if the container does not have more integers of that width.
+    /// Returns [`None`] if the container does not have more integers of that width.
     ///
     /// Behavior is undefined if `width > 64`.
     unsafe fn pop_int(&mut self, width: usize) -> Option<u64>;
@@ -270,7 +270,7 @@ pub trait PopRaw {
 
 //-----------------------------------------------------------------------------
 
-/// A contiguous growable array of bits and up to 64-bit integers based on [`Vec`] of `u64` values.
+/// A contiguous growable array of bits and up to 64-bit integers based on [`Vec`] of [`u64`] values.
 ///
 /// There are no iterators over the vector, because it may contain items of varying widths.
 ///

--- a/src/raw_vector.rs
+++ b/src/raw_vector.rs
@@ -914,4 +914,11 @@ impl<'a> MemoryMapped<'a> for RawVectorMapper<'a> {
     }
 }
 
+impl<'a> AsRef<MappedSlice<'a, u64>> for RawVectorMapper<'a> {
+    #[inline]
+    fn as_ref(&self) -> &MappedSlice<'a, u64> {
+        &(self.data)
+    }
+}
+
 //-----------------------------------------------------------------------------

--- a/src/raw_vector.rs
+++ b/src/raw_vector.rs
@@ -602,8 +602,8 @@ impl Serialize for RawVector {
         })
     }
 
-    fn size_in_bytes(&self) -> usize {
-        self.len.size_in_bytes() + self.data.size_in_bytes()
+    fn size_in_elements(&self) -> usize {
+        self.len.size_in_elements() + self.data.size_in_elements()
     }
 }
 

--- a/src/raw_vector.rs
+++ b/src/raw_vector.rs
@@ -275,6 +275,7 @@ pub trait PopRaw {
 /// There are no iterators over the vector, because it may contain items of varying widths.
 ///
 /// # Notes
+///
 /// * The unused part of the last integer is always set to `0`.
 /// * The underlying vector may allocate but not use more integers than are strictly necessary.
 /// * `RawVector` never panics from I/O errors.
@@ -792,5 +793,19 @@ impl Drop for RawVectorWriter {
         let _ = self.close();
     }
 }
+
+//-----------------------------------------------------------------------------
+
+// FIXME RawVectorMapper
+
+// FIXME impl RawVectorMapper: len, is_empty, new (filename, mode), with_offset(filename, mode, offset)
+
+//-----------------------------------------------------------------------------
+
+// FIXME impl AccessRaw for RawVectorMapper
+
+// FIXME need a Mapper trait similar to Writer in serialize
+
+// FIXME impl Drop for RawVectorMapper
 
 //-----------------------------------------------------------------------------

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -82,6 +82,9 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{env, io, marker, mem, process, ptr, slice};
 
+#[cfg(test)]
+mod tests;
+
 //-----------------------------------------------------------------------------
 
 /// Serialize a data structure.
@@ -906,64 +909,6 @@ pub fn temp_file_name(name_part: &str) -> PathBuf {
     let mut buf = env::temp_dir();
     buf.push(format!("{}_{}_{}", name_part, process::id(), count));
     buf
-}
-
-//-----------------------------------------------------------------------------
-
-// FIXME also test maps
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-
-    #[test]
-    fn serialize_usize() {
-        let filename = temp_file_name("usize");
-
-        let original: usize = 0x1234_5678_9ABC_DEF0;
-        assert_eq!(original.size_in_bytes(), 8, "Invalid serialized size for usize");
-        serialize_to(&original, &filename).unwrap();
-
-        let copy: usize = load_from(&filename).unwrap();
-        assert_eq!(copy, original, "Serialization changed the value of usize");
-
-        fs::remove_file(&filename).unwrap();
-    }
-
-    #[test]
-    fn serialize_option() {
-        let filename = temp_file_name("option");
-
-        {
-            let original: Option<usize> = None;
-            assert_eq!(original.size_in_bytes(), 8, "Invalid serialized size for empty Option<usize>");
-            serialize_to(&original, &filename).unwrap();
-            let copy: Option<usize> = load_from(&filename).unwrap();
-            assert_eq!(copy, original, "Serialization changed the value of empty Option<usize>");
-        }
-
-        {
-            let original: Option<usize> = Some(123456);
-            assert_eq!(original.size_in_bytes(), 16, "Invalid serialized size for non-empty Option<usize>");
-            serialize_to(&original, &filename).unwrap();
-            let copy: Option<usize> = load_from(&filename).unwrap();
-            assert_eq!(copy, original, "Serialization changed the value of non-empty Option<usize>");
-        }
-    }
-
-    #[test]
-    fn serialize_vec_u64() {
-        let filename = temp_file_name("vec_u64");
-
-        let original: Vec<u64> = vec![1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89];
-        assert_eq!(original.size_in_bytes(), 8 + 8 * original.len(), "Invalid serialized size for Vec<u64>");
-        serialize_to(&original, &filename).unwrap();
-
-        let copy: Vec<u64> = load_from(&filename).unwrap();
-        assert_eq!(copy, original, "Serialization changed the value of Vec<u64>");
-
-        fs::remove_file(&filename).unwrap();
-    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -576,9 +576,8 @@ impl MemoryMap {
 
     /// Returns a mutable slice corresponding to the file.
     ///
-    /// This is unsafe, because the mutable slice is borrowed from an immutable `self`.
     /// Behavior is undefined if the file was opened with mode `MappingMode::ReadOnly`.
-    pub unsafe fn as_mut_slice(&self) -> &mut [u64] {
+    pub unsafe fn as_mut_slice(&mut self) -> &mut [u64] {
         slice::from_raw_parts_mut(self.ptr, self.len)
     }
 
@@ -673,7 +672,7 @@ impl Drop for MemoryMap {
 /// fs::remove_file(&filename).unwrap();
 /// ```
 pub trait MemoryMapped<'a>: Sized {
-    /// Returns a memory-mapped structure corresponding to an interval in the file.
+    /// Returns an immutable memory-mapped structure corresponding to an interval in the file.
     ///
     /// # Arguments
     ///

--- a/src/serialize/tests.rs
+++ b/src/serialize/tests.rs
@@ -1,0 +1,122 @@
+use super::*;
+use std::fmt::Debug;
+use std::{fs, mem};
+
+//-----------------------------------------------------------------------------
+
+fn serialized_vector<P, T>(filename: P, correct: &Vec<T>, name: &str) where
+    P: AsRef<Path>,
+    T: Serializable + Debug + PartialEq
+{
+    assert_eq!(correct.size_in_bytes(), 8 + mem::size_of::<T>() * correct.len(), "Invalid serialization size for {}", name);
+    serialize_to(correct, &filename).unwrap();
+    let copy: Vec<T> = load_from(&filename).unwrap();
+    assert_eq!(&copy, correct, "Serialization changed vector {}", name);
+}
+
+fn mapped_vector<P, T>(filename: P, correct: &Vec<T>, name: &str) where
+    P: AsRef<Path>,
+    T: Serializable + Debug + PartialEq
+{
+    let map = MemoryMap::new(&filename, MappingMode::ReadOnly).unwrap();
+    assert!(!map.is_empty(), "The file is empty for vector {}", name);
+    assert_eq!(map.len(), correct.size_in_bytes() / 8, "Invalid file size for {}", name);
+
+    let mapped = MappedSlice::<T>::new(&map, 0).unwrap();
+    assert_eq!(mapped.is_empty(), correct.is_empty(), "Invaid emptiness for mapped slice of {}", name);
+    assert_eq!(mapped.len(), correct.len(), "Invalid length for mapped slice of {}", name);
+    for i in 0..mapped.len() {
+        assert_eq!(mapped[i], correct[i], "Invalid value {} in {}", i, name);
+    }
+    assert_eq!(mapped.as_ref(), correct.as_slice(), "Invalid mapped slice for {}", name);
+}
+
+fn serialized_option<P: AsRef<Path>>(filename: P, correct: &Option<Vec<u64>>, name: &str) {
+    let expected_size: usize = 8 + match correct {
+        Some(value) => value.size_in_bytes(),
+        None => 0,
+    };
+    assert_eq!(correct.size_in_bytes(), expected_size, "Invalid serialization size for {}", name);
+    serialize_to(correct, &filename).unwrap();
+    let copy: Option<Vec<u64>> = load_from(&filename).unwrap();
+    assert_eq!(&copy, correct, "Serialization changed option {}", name);
+}
+
+fn mapped_option<P: AsRef<Path>>(filename: P, correct: &Option<Vec<u64>>, name: &str) {
+    let map = MemoryMap::new(&filename, MappingMode::ReadOnly).unwrap();
+    assert!(!map.is_empty(), "The file is empty for option {}", name);
+    assert_eq!(map.len(), correct.size_in_bytes() / 8, "Invalid file size for {}", name);
+
+    let mapped = MappedOption::<MappedSlice<u64>>::new(&map, 0).unwrap();
+    assert_eq!(mapped.is_some(), correct.is_some(), "Invalid is_some() for {}", name);
+    assert_eq!(mapped.is_none(), correct.is_none(), "Invalid is_none() for {}", name);
+    if mapped.is_some() {
+        assert_eq!(mapped.unwrap(), mapped.as_ref().unwrap(), "Different results with unwrap() options for {}", name);
+        assert_eq!(mapped.unwrap().as_ref(), correct.as_ref().unwrap().as_slice(), "Invalid content for {}", name);
+    } else {
+        assert_eq!(mapped.as_ref(), None, "Got a Some value for {}", name);
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+#[test]
+fn serialize_usize() {
+    let filename = temp_file_name("usize");
+
+    let original: usize = 0x1234_5678_9ABC_DEF0;
+    assert_eq!(original.size_in_bytes(), 8, "Invalid serialized size for usize");
+    serialize_to(&original, &filename).unwrap();
+
+    let copy: usize = load_from(&filename).unwrap();
+    assert_eq!(copy, original, "Serialization changed the value of usize");
+
+    fs::remove_file(&filename).unwrap();
+}
+
+#[test]
+fn serialize_vec_u64() {
+    let filename = temp_file_name("vec-u64");
+
+    let empty: Vec<u64> = Vec::new();
+    serialized_vector(&filename, &empty, "empty");
+    mapped_vector(&filename, &empty, "empty");
+
+    let original: Vec<u64> = vec![1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89];
+    serialized_vector(&filename, &original, "non-empty");
+    mapped_vector(&filename, &original, "non-empty");
+
+    fs::remove_file(&filename).unwrap();
+}
+
+#[test]
+fn serialize_vec_u64_u64() {
+    let filename = temp_file_name("vec-u64-u64");
+
+    let empty: Vec<(u64, u64)> = Vec::new();
+    serialized_vector(&filename, &empty, "empty");
+    mapped_vector(&filename, &empty, "empty");
+
+    let original: Vec<(u64, u64)> = vec![(1, 1), (2, 3), (5, 8), (13, 21), (34, 55), (89, 144)];
+    serialized_vector(&filename, &original, "non-empty");
+    mapped_vector(&filename, &original, "non-empty");
+
+    fs::remove_file(&filename).unwrap();
+}
+
+#[test]
+fn serialize_option() {
+    let filename = temp_file_name("option");
+
+    let none: Option<Vec<u64>> = None;
+    serialized_option(&filename, &none, "none");
+    mapped_option(&filename, &none, "none");
+
+    let some: Option<Vec<u64>> = Some(vec![1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89]);
+    serialized_option(&filename, &some, "some");
+    mapped_option(&filename, &some, "some");
+
+    fs::remove_file(&filename).unwrap();
+}
+
+//-----------------------------------------------------------------------------

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -795,11 +795,11 @@ impl Serialize for SparseVector {
         Ok(result)
     }
 
-    fn size_in_bytes(&self) -> usize {
-        self.len.size_in_bytes() +
-        self.width.size_in_bytes() +
-        self.high.size_in_bytes() +
-        self.low.size_in_bytes()
+    fn size_in_elements(&self) -> usize {
+        self.len.size_in_elements() +
+        self.width.size_in_elements() +
+        self.high.size_in_elements() +
+        self.low.size_in_elements()
     }
 }
 

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -784,7 +784,11 @@ impl Serialize for SparseVector {
     fn load<T: io::Read>(reader: &mut T) -> io::Result<Self> {
         let len = usize::load(reader)?;
         let width = usize::load(reader)?;
-        let high = BitVector::load(reader)?;
+        let mut high = BitVector::load(reader)?;
+        // Enable support structures, because the data may be from a library that does not know
+        // how to build them.
+        high.enable_select();
+        high.enable_select_zero();
         let low = IntVector::load(reader)?;
         let result = SparseVector {
             len: len,

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -40,11 +40,10 @@ mod tests;
 /// This structure should be used for sparse bitvectors, where frequency of set bits is low.
 /// For dense bitvectors or when [`SelectZero`] is needed, [`BitVector`] is a better choice.
 /// Because most queries require support structures for one of the components, the bitvector itself is immutable.
-/// The maximum length of the vector is approximately `usize::MAX` bits.
+/// The maximum length of the vector is approximately [`usize::MAX`] bits.
 ///
 /// Conversions between `SparseVector` and [`BitVector`] are possible using the [`From`] trait.
 /// 
-///
 /// `SparseVector` implements the following `simple_sds` traits:
 /// * Basic functionality: [`BitVec`]
 /// * Queries and operations: [`Rank`], [`Select`], [`PredSucc`]
@@ -126,7 +125,7 @@ struct Parts {
 impl SparseVector {
     /// Returns a copy of the source bitvector as `SparseVector`.
     ///
-    /// The copy is created by iterating over the set bits using [`Select::one_iter()`].
+    /// The copy is created by iterating over the set bits using [`Select::one_iter`].
     ///
     /// # Examples
     ///
@@ -247,7 +246,7 @@ pub struct SparseBuilder {
 impl SparseBuilder {
     /// Returns an empty SparseBuilder.
     ///
-    /// Returns `Err` if `ones > universe`.
+    /// Returns [`Err`] if `ones > universe`.
     ///
     /// # Arguments
     ///
@@ -327,7 +326,7 @@ impl SparseBuilder {
 
     /// Tries to set the specified bit in the bitvector.
     ///
-    /// Returns `Err` if the builder is full, if `index < self.next_index()`, or if `index >= self.universe()`.
+    /// Returns [`Err`] if the builder is full, if `index < self.next_index()`, or if `index >= self.universe()`.
     pub fn try_set(&mut self, index: usize) -> Result<(), &'static str> {
         if self.is_full() {
             return Err("The builder is full");
@@ -355,7 +354,7 @@ impl Extend<usize> for SparseBuilder {
 
 /// A read-only iterator over [`SparseVector`].
 ///
-/// The type of `Item` is `bool`.
+/// The type of `Item` is [`bool`].
 ///
 /// # Examples
 ///
@@ -550,7 +549,7 @@ impl<'a> Rank<'a> for SparseVector {
 
 /// An iterator over the set bits in [`SparseVector`].
 ///
-/// The type of `Item` is `(usize, usize)`.
+/// The type of `Item` is `(`[`usize`]`, `[`usize`]`)`.
 /// This can be interpreted as:
 ///
 /// * `(index, value)` or `(i, select(i))` in the integer array; or


### PR DESCRIPTION
# Serialization changes

* Trait `Serializable` indicates a fixed-length object that can be serialized as one or more `u64` elements.
* A `Vec` of `Serializable` objects can always be serialized.
* The size of a serialized object is now expressed in terms of `u64` elements.

# Memory-mapped objects

* `MemoryMap` maps the file as an array of `u64` elements. The file can be opened as read-only or mutable.
* Trait `MemoryMapped` indicates a memory-mapped object starting at a specified offset of a `MemoryMap`.
* `MappedSlice` is an immutable memory-mapped slice of a `Serializable` type compatible with the serialization format of `Vec` of the same type.
* `MappedOption` is an optional memory-mapped object compatible with the serialization format of `Option` of the same type.
* `RawVectorMapper` and `IntVectorMapper` are immutable memory-mapped vectors compatible with the serialization formats of `RawVector` and `IntVector`, respectively.