### PR TITLE
Validate on load

### DIFF
--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -7,6 +7,7 @@ use crate::raw_vector::{RawVector, AccessRaw, PushRaw};
 use crate::serialize::Serialize;
 use crate::bits;
 
+use std::io::{Error, ErrorKind};
 use std::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, FromIterator};
 use std::{io, marker};
 
@@ -622,21 +623,41 @@ impl Serialize for BitVector {
         Ok(())
     }
 
-    // FIXME: Sanity checks: number of blocks in rank, select, select_zero
     fn load<T: io::Read>(reader: &mut T) -> io::Result<Self> {
         let ones = usize::load(reader)?;
         let data = RawVector::load(reader)?;
+        if ones > data.len() {
+            return Err(Error::new(ErrorKind::InvalidData, "Invalid count of ones"));
+        }
+
         let rank = Option::<RankSupport>::load(reader)?;
+        if let Some(value) = rank.as_ref() {
+            if value.blocks() != bits::div_round_up(data.len(), RankSupport::BLOCK_SIZE) {
+                return Err(Error::new(ErrorKind::InvalidData, "Invalid number of rank blocks"))
+            }
+        }
+
         let select = Option::<SelectSupport<Identity>>::load(reader)?;
+        if let Some(value) = select.as_ref() {
+            if value.superblocks() != bits::div_round_up(ones, SelectSupport::<Identity>::SUPERBLOCK_SIZE) {
+                return Err(Error::new(ErrorKind::InvalidData, "Invalid number of select superblocks"))
+            }
+        }
+
         let select_zero = Option::<SelectSupport<Complement>>::load(reader)?;
-        let result = BitVector {
+        if let Some(value) = select_zero.as_ref() {
+            if value.superblocks() != bits::div_round_up(data.len() - ones, SelectSupport::<Complement>::SUPERBLOCK_SIZE) {
+                return Err(Error::new(ErrorKind::InvalidData, "Invalid number of select_zero superblocks"))
+            }
+        }
+
+        Ok(BitVector {
             ones: ones,
             data: data,
             rank: rank,
             select: select,
             select_zero: select_zero,
-        };
-        Ok(result)
+        })
     }
 
     fn size_in_elements(&self) -> usize {

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -622,6 +622,7 @@ impl Serialize for BitVector {
         Ok(())
     }
 
+    // FIXME: Sanity checks: number of blocks in rank, select, select_zero
     fn load<T: io::Read>(reader: &mut T) -> io::Result<Self> {
         let ones = usize::load(reader)?;
         let data = RawVector::load(reader)?;

--- a/src/bit_vector/rank_support.rs
+++ b/src/bit_vector/rank_support.rs
@@ -42,7 +42,9 @@ pub struct RankSupport {
 }
 
 impl RankSupport {
-    const BLOCK_SIZE: usize = 512;
+    /// Number of bits per block (512).
+    pub const BLOCK_SIZE: usize = 512;
+
     const RELATIVE_RANK_BITS: usize = 9;
     const RELATIVE_RANK_MASK: usize = 0x1FF;
     const WORDS_PER_BLOCK: usize = 8;

--- a/src/bit_vector/select_support.rs
+++ b/src/bit_vector/select_support.rs
@@ -265,6 +265,7 @@ impl<T: Transformation> Serialize for SelectSupport<T> {
         Ok(())
     }
 
+    // FIXME: Sanity checks: long + short == total superblocks
     fn load<W: io::Read>(reader: &mut W) -> io::Result<Self> {
         let samples = IntVector::load(reader)?;
         let long = IntVector::load(reader)?;

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -226,6 +226,26 @@ pub fn bits_to_words(n: usize) -> usize {
     (n + WORD_BITS - 1) / WORD_BITS
 }
 
+/// Divides `value` by `n` and rounds the result up.
+///
+/// # Examples
+///
+/// ```
+/// use simple_sds::bits;
+///
+/// assert_eq!(bits::div_round_up(129, 13), 10);
+/// assert_eq!(bits::div_round_up(130, 13), 10);
+/// assert_eq!(bits::div_round_up(131, 13), 11);
+/// ```
+///
+/// # Panics
+///
+/// May panic if `value + n > usize::MAX` or `n == 0`.
+#[inline]
+pub fn div_round_up(value: usize, n: usize) -> usize {
+    (value + n - 1) / n
+}
+
 /// Rounds `n` up to the next positive multiple of 64.
 ///
 /// # Examples

--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -289,11 +289,16 @@ impl Serialize for IntVector {
         let len = usize::load(reader)?;
         let width = usize::load(reader)?;
         let data = RawVector::load(reader)?;
-        Ok(IntVector {
-            len: len,
-            width: width,
-            data: data,
-        })
+        if len * width != data.len() {
+            Err(Error::new(ErrorKind::InvalidData, "Data length does not match len * width"))
+        }
+        else {
+            Ok(IntVector {
+                len: len,
+                width: width,
+                data: data,
+            })
+        }
     }
 
     fn size_in_elements(&self) -> usize {

--- a/src/int_vector/tests.rs
+++ b/src/int_vector/tests.rs
@@ -240,6 +240,27 @@ fn serialize() {
     fs::remove_file(&filename).unwrap();
 }
 
+#[test]
+fn invalid_data() {
+    let filename = serialize::temp_file_name("int-vector-invalid-data");
+    let mut options = OpenOptions::new();
+    let mut file = options.create(true).write(true).truncate(true).open(&filename).unwrap();
+
+    // 13 values of 20 bits each will take 260 bits, but data length is 240 bits
+    let len: usize = 13;
+    let width: usize = 20;
+    let data = RawVector::with_len(240, false);
+    len.serialize(&mut file).unwrap();
+    width.serialize(&mut file).unwrap();
+    data.serialize(&mut file).unwrap();
+    drop(file);
+
+    let result: io::Result<IntVector> = serialize::load_from(&filename);
+    assert_eq!(result.map_err(|e| e.kind()), Err(ErrorKind::InvalidData), "Expected ErrorKind::InvalidData");
+
+    fs::remove_file(&filename).unwrap();
+}
+
 //-----------------------------------------------------------------------------
 
 #[test]

--- a/src/raw_vector.rs
+++ b/src/raw_vector.rs
@@ -597,10 +597,14 @@ impl Serialize for RawVector {
     fn load<T: io::Read>(reader: &mut T) -> io::Result<Self> {
         let len = usize::load(reader)?;
         let data = <Vec<u64> as Serialize>::load(reader)?;
-        Ok(RawVector {
-            len: len,
-            data: data,
-        })
+        if bits::bits_to_words(len) != data.len() {
+            Err(Error::new(ErrorKind::InvalidData, "Bit length / word length mismatch"))
+        } else {
+            Ok(RawVector {
+                len: len,
+                data: data,
+            })
+        }
     }
 
     fn size_in_elements(&self) -> usize {

--- a/src/raw_vector/tests.rs
+++ b/src/raw_vector/tests.rs
@@ -227,6 +227,25 @@ fn serialize() {
     fs::remove_file(&filename).unwrap();
 }
 
+#[test]
+fn invalid_data() {
+    let filename = serialize::temp_file_name("raw-vector-invalid-data");
+    let mut options = OpenOptions::new();
+    let mut file = options.create(true).write(true).truncate(true).open(&filename).unwrap();
+
+    // 123 bits will fit in 2 words, but data length is 3.
+    let len: usize = 123;
+    let data: Vec<u64> = vec![123, 456, 789];
+    len.serialize(&mut file).unwrap();
+    data.serialize(&mut file).unwrap();
+    drop(file);
+
+    let result: io::Result<RawVector> = serialize::load_from(&filename);
+    assert_eq!(result.map_err(|e| e.kind()), Err(ErrorKind::InvalidData), "Expected ErrorKind::InvalidData");
+
+    fs::remove_file(&filename).unwrap();
+}
+
 //-----------------------------------------------------------------------------
 
 #[test]

--- a/src/serialize/tests.rs
+++ b/src/serialize/tests.rs
@@ -119,4 +119,23 @@ fn serialize_option() {
     fs::remove_file(&filename).unwrap();
 }
 
+#[test]
+fn invalid_data() {
+    let filename = temp_file_name("serialize-invalid-data");
+    let mut options = OpenOptions::new();
+    let mut file = options.create(true).write(true).truncate(true).open(&filename).unwrap();
+
+    // The size of `u64` is one element, but the header indicates that it should take two.
+    let size: usize = 2;
+    let value: u64 = 123;
+    size.serialize(&mut file).unwrap();
+    value.serialize(&mut file).unwrap();
+    drop(file);
+
+    let result: io::Result<Option<u64>> = load_from(&filename);
+    assert_eq!(result.map_err(|e| e.kind()), Err(ErrorKind::InvalidData), "Expected ErrorKind::InvalidData");
+
+    fs::remove_file(&filename).unwrap();
+}
+
 //-----------------------------------------------------------------------------

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -27,6 +27,7 @@ use crate::serialize::Serialize;
 use crate::bits;
 
 use std::convert::TryFrom;
+use std::io::{Error, ErrorKind};
 use std::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Extend};
 use std::{cmp, io};
 
@@ -103,7 +104,6 @@ mod tests;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SparseVector {
     len: usize,
-    width: usize,
     high: BitVector,
     low: IntVector,
 }
@@ -152,14 +152,14 @@ impl SparseVector {
     // Split a bitvector index into high and low parts.
     fn split(&self, index: usize) -> Parts {
         Parts {
-            high: index >> self.width,
-            low: index & unsafe { bits::low_set_unchecked(self.width) as usize },
+            high: index >> self.low.width(),
+            low: index & unsafe { bits::low_set_unchecked(self.low.width()) as usize },
         }
     }
 
     // Get (rank, bitvector index) from the offsets in `high` and `low`.
     fn combine(&self, pos: Pos) -> (usize, usize) {
-        (pos.low, ((pos.high - pos.low) << self.width) + (self.low.get(pos.low) as usize))
+        (pos.low, ((pos.high - pos.low) << self.low.width()) + (self.low.get(pos.low) as usize))
     }
 
     // Get the offsets in `high` and `low` for the set bit of the given rank.
@@ -257,27 +257,31 @@ impl SparseBuilder {
             return Err("Number of set bits is greater than universe size");
         }
 
-        let log_n = bits::bit_len(universe as u64);
-        let mut log_m = bits::bit_len(ones as u64);
-        if log_m == log_n {
-            log_m -= 1;
-        }
-        let width: usize = log_n - log_m;
+        let (width, high_len) = Self::get_params(universe, ones);
         let low = IntVector::with_len(ones, width, 0).unwrap();
         let data = SparseVector {
             len: universe,
-            width: width,
             high: BitVector::from(RawVector::new()),
             low: low,
         };
 
-        let high = RawVector::with_len(ones + (1usize << log_m), false);
+        let high = RawVector::with_len(high_len, false);
         Ok(SparseBuilder {
             data: data,
             high: high,
             len: 0,
             next: 0,
         })
+    }
+
+    // Returns `(low.width(), high.len())`.
+    fn get_params(universe: usize, ones: usize) -> (usize, usize) {
+        let log_n = bits::bit_len(universe as u64);
+        let mut log_m = bits::bit_len(ones as u64);
+        if log_m == log_n {
+            log_m -= 1;
+        }
+        (log_n - log_m, ones + (1usize << log_m))
     }
 
     /// Returns the number of bits that have already been set.
@@ -771,7 +775,6 @@ impl<'a> PredSucc<'a> for SparseVector {
 impl Serialize for SparseVector {
     fn serialize_header<T: io::Write>(&self, writer: &mut T) -> io::Result<()> {
         self.len.serialize(writer)?;
-        self.width.serialize(writer)?;
         Ok(())
     }
 
@@ -781,19 +784,30 @@ impl Serialize for SparseVector {
         Ok(())
     }
 
-    // FIXME: Sanity checks: len, width, high, low
     fn load<T: io::Read>(reader: &mut T) -> io::Result<Self> {
         let len = usize::load(reader)?;
-        let width = usize::load(reader)?;
         let mut high = BitVector::load(reader)?;
+        let low = IntVector::load(reader)?;
+
         // Enable support structures, because the data may be from a library that does not know
         // how to build them.
         high.enable_select();
         high.enable_select_zero();
-        let low = IntVector::load(reader)?;
+
+        // Sanity checks.
+        if low.len() > len {
+            return Err(Error::new(ErrorKind::InvalidData, "Invalid count of ones"))
+        }
+        let (low_width, high_len) = SparseBuilder::get_params(len, low.len());
+        if low.width() != low_width {
+            return Err(Error::new(ErrorKind::InvalidData, "Invalid low width"))
+        }
+        if high.len() != high_len {
+            return Err(Error::new(ErrorKind::InvalidData, "Invalid high_length"))
+        }
+
         let result = SparseVector {
             len: len,
-            width: width,
             high: high,
             low: low,
         };
@@ -802,7 +816,6 @@ impl Serialize for SparseVector {
 
     fn size_in_elements(&self) -> usize {
         self.len.size_in_elements() +
-        self.width.size_in_elements() +
         self.high.size_in_elements() +
         self.low.size_in_elements()
     }

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -781,6 +781,7 @@ impl Serialize for SparseVector {
         Ok(())
     }
 
+    // FIXME: Sanity checks: len, width, high, low
     fn load<T: io::Read>(reader: &mut T) -> io::Result<Self> {
         let len = usize::load(reader)?;
         let width = usize::load(reader)?;


### PR DESCRIPTION
`Serialize::load` implementations now do sanity checks based on header information and return an error (`ErrorKind::InvalidData`) if the checks fail. This should catch invalid / corrupted data in many situations. Full validation would be too expensive for large data structures in high-performance applications.

Some redundant information has been removed from the header of `SparseVector`.