### PR TITLE
Serialize bytes

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -6,6 +6,9 @@ use std::ops::{Index, IndexMut};
 
 //-----------------------------------------------------------------------------
 
+/// Number of bytes in [`u64`].
+pub const WORD_BYTES: usize = 8;
+
 /// Number of bits in [`u64`].
 pub const WORD_BITS: usize = 64;
 
@@ -189,6 +192,65 @@ pub unsafe fn select(n: u64, rank: usize) -> usize {
 
 //-----------------------------------------------------------------------------
 
+/// Returns the number of bytes that can be stored in `n` integers of type [`u64`].
+///
+/// # Examples
+///
+/// ```
+/// use simple_sds::bits;
+///
+/// assert_eq!(bits::words_to_bytes(3), 24);
+/// ```
+///
+/// # Panics
+///
+/// May panic if `n * 8 > usize::MAX`.
+#[inline]
+pub fn words_to_bytes(n: usize) -> usize {
+    n * WORD_BYTES
+}
+
+/// Returns the number of integers of type [`u64`] required to store `n` bytes.
+///
+/// # Examples
+///
+/// ```
+/// use simple_sds::bits;
+///
+/// assert_eq!(bits::bytes_to_words(8), 1);
+/// assert_eq!(bits::bytes_to_words(9), 2);
+/// ```
+///
+/// # Panics
+///
+/// May panic if `n + 7 > usize::MAX`.
+#[inline]
+pub fn bytes_to_words(n: usize) -> usize {
+    (n + WORD_BYTES - 1) / WORD_BYTES
+}
+
+/// Rounds `n` up to the next multiple of 8.
+///
+/// # Examples
+///
+/// ```
+/// use simple_sds::bits;
+///
+/// assert_eq!(bits::round_up_to_word_bytes(0), 0);
+/// assert_eq!(bits::round_up_to_word_bytes(8), 8);
+/// assert_eq!(bits::round_up_to_word_bytes(9), 16);
+/// ```
+///
+/// # Panics
+///
+/// May panic if `n + 7 > usize::MAX`.
+#[inline]
+pub fn round_up_to_word_bytes(n: usize) -> usize {
+    words_to_bytes(bytes_to_words(n))
+}
+
+//-----------------------------------------------------------------------------
+
 /// Returns the number of bits that can be stored in `n` integers of type [`u64`].
 ///
 /// # Examples
@@ -226,6 +288,28 @@ pub fn bits_to_words(n: usize) -> usize {
     (n + WORD_BITS - 1) / WORD_BITS
 }
 
+/// Rounds `n` up to the next multiple of 64.
+///
+/// # Examples
+///
+/// ```
+/// use simple_sds::bits;
+///
+/// assert_eq!(bits::round_up_to_word_bits(0), 0);
+/// assert_eq!(bits::round_up_to_word_bits(64), 64);
+/// assert_eq!(bits::round_up_to_word_bits(65), 128);
+/// ```
+///
+/// # Panics
+///
+/// May panic if `n + 63 > usize::MAX`.
+#[inline]
+pub fn round_up_to_word_bits(n: usize) -> usize {
+    words_to_bits(bits_to_words(n))
+}
+
+//-----------------------------------------------------------------------------
+
 /// Divides `value` by `n` and rounds the result up.
 ///
 /// # Examples
@@ -244,29 +328,6 @@ pub fn bits_to_words(n: usize) -> usize {
 #[inline]
 pub fn div_round_up(value: usize, n: usize) -> usize {
     (value + n - 1) / n
-}
-
-/// Rounds `n` up to the next positive multiple of 64.
-///
-/// # Examples
-///
-/// ```
-/// use simple_sds::bits;
-///
-/// assert_eq!(bits::round_up_to_word_size(0), 64);
-/// assert_eq!(bits::round_up_to_word_size(64), 64);
-/// assert_eq!(bits::round_up_to_word_size(65), 128);
-/// ```
-///
-/// # Panics
-///
-/// May panic if `n + 63 > usize::MAX`.
-#[inline]
-pub fn round_up_to_word_size(n: usize) -> usize {
-    match n {
-        0 => WORD_BITS,
-        _ => words_to_bits(bits_to_words(n)),
-    }
 }
 
 /// Returns a [`u64`] value consisting entirely of bit `value`.

--- a/src/raw_vector.rs
+++ b/src/raw_vector.rs
@@ -6,7 +6,7 @@ use crate::bits;
 use std::fs::{File, OpenOptions};
 use std::io::{Error, ErrorKind};
 use std::path::Path;
-use std::io;
+use std::{cmp, io};
 
 #[cfg(test)]
 mod tests;
@@ -708,7 +708,8 @@ impl RawVectorWriter {
     /// * `filename`: Name of the file.
     /// * `buf_len`: Buffer size in bits.
     pub fn with_buf_len<P: AsRef<Path>>(filename: P, buf_len: usize) -> io::Result<RawVectorWriter> {
-        let buf_len = bits::round_up_to_word_size(buf_len);
+        // Buffer length must be a positive multiple of `bits::WORD_BITS`.
+        let buf_len = cmp::max(bits::round_up_to_word_bits(buf_len), bits::WORD_BITS);
         let mut options = OpenOptions::new();
         let file = options.create(true).write(true).truncate(true).open(filename)?;
         // Allocate one extra word for overflow.

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -78,9 +78,11 @@
 //!
 //! A file may contain multiple nested or concatenated structures.
 //! Trait [`MemoryMapped`] represents a memory-mapped structure that borrows an interval of the memory map.
-//! There are two implementations of [`MemoryMapped`] for basic serialization types:
+//! There are four implementations of [`MemoryMapped`] for basic serialization types:
 //!
-//! * [`MappedSlice`] matches the serialization format of [`Vec`].
+//! * [`MappedSlice`] matches the serialization format of [`Vec`] of a [`Serializable`] type.
+//! * [`MappedBytes`] matches the serialization format of [`Vec`] of [`u8`].
+//! * [`MappedStr`] matches the serialization format of [`String`].
 //! * [`MappedOption`] matches the serialization format of [`Option`].
 
 use crate::bits;
@@ -91,7 +93,7 @@ use std::ops::Index;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::{env, io, marker, mem, process, ptr, slice};
+use std::{env, io, marker, mem, process, ptr, slice, str};
 
 #[cfg(test)]
 mod tests;
@@ -843,7 +845,7 @@ impl<'a, T: Serializable> MemoryMapped<'a> for MappedSlice<'a, T> {
         if offset + 1 + len * T::elements() > map.len() {
             return Err(Error::new(ErrorKind::UnexpectedEof, "The file is too short"));
         }
-        let source: &[u64] = &slice[offset + 1 .. offset + 1 + len * T::elements()];
+        let source: &[u64] = &slice[offset + 1 ..];
         let data: &[T] = unsafe { slice::from_raw_parts(source.as_ptr() as *const T, len) };
         Ok(MappedSlice {
             data: data,
@@ -856,7 +858,170 @@ impl<'a, T: Serializable> MemoryMapped<'a> for MappedSlice<'a, T> {
     }
 
     fn map_len(&self) -> usize {
-        self.data.len() * T::elements() + 1
+        self.len() * T::elements() + 1
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+/// An immutable memory-mapped slice of [`u8`].
+///
+/// The slice is compatible with the serialization format of [`Vec`] of [`u8`].
+///
+/// # Examples
+///
+/// ```
+/// use simple_sds::serialize::{MappedBytes, MappingMode, MemoryMap, MemoryMapped, Serialize};
+/// use simple_sds::serialize;
+/// use std::fs;
+///
+/// let v: Vec<u8> = vec![1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233];
+/// let filename = serialize::temp_file_name("mapped-bytes");
+/// serialize::serialize_to(&v, &filename);
+///
+/// let map = MemoryMap::new(&filename, MappingMode::ReadOnly).unwrap();
+/// let mapped = MappedBytes::new(&map, 0).unwrap();
+/// assert_eq!(mapped.len(), v.len());
+/// assert_eq!(mapped[3], 3);
+/// assert_eq!(mapped[6], 13);
+/// assert_eq!(mapped.as_ref(), v.as_slice());
+/// drop(mapped); drop(map);
+///
+/// fs::remove_file(&filename).unwrap();
+/// ```
+#[derive(PartialEq, Eq, Debug)]
+pub struct MappedBytes<'a> {
+    data: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> MappedBytes<'a> {
+    /// Returns the length of the slice.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns `true` if the slice is empty.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+impl<'a> AsRef<[u8]> for MappedBytes<'a> {
+    fn as_ref(&self) -> &[u8] {
+        self.data
+    }
+}
+
+impl<'a> Index<usize> for MappedBytes<'a> {
+    type Output = u8;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.data[index]
+    }
+}
+
+impl<'a> MemoryMapped<'a> for MappedBytes<'a> {
+    fn new(map: &'a MemoryMap, offset: usize) -> io::Result<Self> {
+        if offset >= map.len() {
+            return Err(Error::new(ErrorKind::UnexpectedEof, "The starting offset is out of range"));
+        }
+        let slice: &[u64] = map.as_ref();
+        let len = slice[offset] as usize;
+        if offset + 1 + bits::bytes_to_words(len) > map.len() {
+            return Err(Error::new(ErrorKind::UnexpectedEof, "The file is too short"));
+        }
+        let source: &[u64] = &slice[offset + 1 ..];
+        let data: &[u8] = unsafe { slice::from_raw_parts(source.as_ptr() as *const u8, len) };
+        Ok(MappedBytes {
+            data: data,
+            offset: offset,
+        })
+    }
+
+    fn map_offset(&self) -> usize {
+        self.offset
+    }
+
+    fn map_len(&self) -> usize {
+        bits::bytes_to_words(self.len()) + 1
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+/// An immutable memory-mapped string slice.
+///
+/// The slice is compatible with the serialization format of [`String`].
+///
+/// # Examples
+///
+/// ```
+/// use simple_sds::serialize::{MappedStr, MappingMode, MemoryMap, MemoryMapped, Serialize};
+/// use simple_sds::serialize;
+/// use std::fs;
+///
+/// let s = String::from("GATTACA");
+/// let filename = serialize::temp_file_name("mapped-str");
+/// serialize::serialize_to(&s, &filename);
+///
+/// let map = MemoryMap::new(&filename, MappingMode::ReadOnly).unwrap();
+/// let mapped = MappedStr::new(&map, 0).unwrap();
+/// assert_eq!(mapped.len(), s.len());
+/// assert_eq!(mapped.as_ref(), s.as_str());
+/// drop(mapped); drop(map);
+///
+/// fs::remove_file(&filename).unwrap();
+/// ```
+#[derive(PartialEq, Eq, Debug)]
+pub struct MappedStr<'a> {
+    data: &'a str,
+    offset: usize,
+}
+
+impl<'a> MappedStr<'a> {
+    /// Returns the length of the slice in bytes.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns `true` if the slice is empty.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+impl<'a> AsRef<str> for MappedStr<'a> {
+    fn as_ref(&self) -> &str {
+        self.data
+    }
+}
+
+impl<'a> MemoryMapped<'a> for MappedStr<'a> {
+    fn new(map: &'a MemoryMap, offset: usize) -> io::Result<Self> {
+        if offset >= map.len() {
+            return Err(Error::new(ErrorKind::UnexpectedEof, "The starting offset is out of range"));
+        }
+        let slice: &[u64] = map.as_ref();
+        let len = slice[offset] as usize;
+        if offset + 1 + bits::bytes_to_words(len) > map.len() {
+            return Err(Error::new(ErrorKind::UnexpectedEof, "The file is too short"));
+        }
+        let source: &[u64] = &slice[offset + 1 ..];
+        let bytes: &[u8] = unsafe { slice::from_raw_parts(source.as_ptr() as *const u8, len) };
+        let data = str::from_utf8(bytes).map_err(|_| Error::new(ErrorKind::InvalidData, "Invalid UTF-8"))?;
+        Ok(MappedStr {
+            data: data,
+            offset: offset,
+        })
+    }
+
+    fn map_offset(&self) -> usize {
+        self.offset
+    }
+
+    fn map_len(&self) -> usize {
+        bits::bytes_to_words(self.len()) + 1
     }
 }
 

--- a/src/serialize/tests.rs
+++ b/src/serialize/tests.rs
@@ -20,7 +20,7 @@ fn mapped_vector<P, T>(filename: P, correct: &Vec<T>, name: &str) where
 {
     let map = MemoryMap::new(&filename, MappingMode::ReadOnly).unwrap();
     assert!(!map.is_empty(), "The file is empty for vector {}", name);
-    assert_eq!(map.len(), correct.size_in_bytes() / 8, "Invalid file size for {}", name);
+    assert_eq!(map.len(), correct.size_in_elements(), "Invalid file size for {}", name);
 
     let mapped = MappedSlice::<T>::new(&map, 0).unwrap();
     assert_eq!(mapped.is_empty(), correct.is_empty(), "Invaid emptiness for mapped slice of {}", name);
@@ -38,11 +38,36 @@ fn serialized_bytes<P: AsRef<Path>>(filename: P, correct: &Vec<u8>, name: &str) 
     assert_eq!(&copy, correct, "Serialization changed vector {}", name);
 }
 
+fn mapped_bytes<P: AsRef<Path>>(filename: P, correct: &Vec<u8>, name: &str) {
+    let map = MemoryMap::new(&filename, MappingMode::ReadOnly).unwrap();
+    assert!(!map.is_empty(), "The file is empty for vector {}", name);
+    assert_eq!(map.len(), correct.size_in_elements(), "Invalid file size for {}", name);
+
+    let mapped = MappedBytes::new(&map, 0).unwrap();
+    assert_eq!(mapped.is_empty(), correct.is_empty(), "Invaid emptiness for mapped slice of {}", name);
+    assert_eq!(mapped.len(), correct.len(), "Invalid length for mapped slice of {}", name);
+    for i in 0..mapped.len() {
+        assert_eq!(mapped[i], correct[i], "Invalid value {} in {}", i, name);
+    }
+    assert_eq!(mapped.as_ref(), correct.as_slice(), "Invalid mapped slice for {}", name);
+}
+
 fn serialized_string<P: AsRef<Path>>(filename: P, correct: &String, name: &str) {
     assert_eq!(correct.size_in_bytes(), 8 + bits::round_up_to_word_bytes(correct.len()), "Invalid serialization size for {}", name);
     serialize_to(correct, &filename).unwrap();
     let copy: String = load_from(&filename).unwrap();
     assert_eq!(&copy, correct, "Serialization changed string {}", name);
+}
+
+fn mapped_string<P: AsRef<Path>>(filename: P, correct: &String, name: &str) {
+    let map = MemoryMap::new(&filename, MappingMode::ReadOnly).unwrap();
+    assert!(!map.is_empty(), "The file is empty for string {}", name);
+    assert_eq!(map.len(), correct.size_in_elements(), "Invalid file size for {}", name);
+
+    let mapped = MappedStr::new(&map, 0).unwrap();
+    assert_eq!(mapped.is_empty(), correct.is_empty(), "Invaid emptiness for mapped string slice of {}", name);
+    assert_eq!(mapped.len(), correct.len(), "Invalid length for mapped string slice of {}", name);
+    assert_eq!(mapped.as_ref(), correct.as_str(), "Invalid mapped string slice for {}", name);
 }
 
 fn serialized_option<P: AsRef<Path>>(filename: P, correct: &Option<Vec<u64>>, name: &str) {
@@ -59,7 +84,7 @@ fn serialized_option<P: AsRef<Path>>(filename: P, correct: &Option<Vec<u64>>, na
 fn mapped_option<P: AsRef<Path>>(filename: P, correct: &Option<Vec<u64>>, name: &str) {
     let map = MemoryMap::new(&filename, MappingMode::ReadOnly).unwrap();
     assert!(!map.is_empty(), "The file is empty for option {}", name);
-    assert_eq!(map.len(), correct.size_in_bytes() / 8, "Invalid file size for {}", name);
+    assert_eq!(map.len(), correct.size_in_elements(), "Invalid file size for {}", name);
 
     let mapped = MappedOption::<MappedSlice<u64>>::new(&map, 0).unwrap();
     assert_eq!(mapped.is_some(), correct.is_some(), "Invalid is_some() for {}", name);
@@ -124,15 +149,15 @@ fn serialize_bytes() {
 
     let empty: Vec<u8> = Vec::new();
     serialized_bytes(&filename, &empty, "empty");
-//    mapped_bytes(&filename, &empty, "empty");
+    mapped_bytes(&filename, &empty, "empty");
 
     let padded: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     serialized_bytes(&filename, &padded, "padded");
-//    mapped_bytes(&filename, &padded, "padded");
+    mapped_bytes(&filename, &padded, "padded");
 
     let unpadded: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
     serialized_bytes(&filename, &unpadded, "unpadded");
-//    mapped_bytes(&filename, &unpadded, "unpadded");
+    mapped_bytes(&filename, &unpadded, "unpadded");
 
     fs::remove_file(&filename).unwrap();
 }
@@ -143,15 +168,15 @@ fn serialize_string() {
 
     let empty = String::new();
     serialized_string(&filename, &empty, "empty");
-//    mapped_string(&filename, &empty, "empty");
+    mapped_string(&filename, &empty, "empty");
 
     let padded = String::from("0123456789ABC");
     serialized_string(&filename, &padded, "padded");
-//    mapped_string(&filename, &padded, "padded");
+    mapped_string(&filename, &padded, "padded");
 
     let unpadded = String::from("0123456789ABCDEF");
     serialized_string(&filename, &unpadded, "unpadded");
-//    mapped_string(&filename, &unpadded, "unpadded");
+    mapped_string(&filename, &unpadded, "unpadded");
 
     fs::remove_file(&filename).unwrap();
 }


### PR DESCRIPTION
Serialization support for `Vec<u8>` and `String`. Both store the length of the data in the header and the concatenated bytes in the body. The body is padded with 0-bytes to the next multiple of 8 bytes. The corresponding memory-mapped structures are `MappedBytes` and `MappedStr`.