### PR TITLE
Smaller SparseVector

### DIFF
--- a/SERIALIZATION.md
+++ b/SERIALIZATION.md
@@ -1,6 +1,6 @@
 # Serialization formats
 
-For version 0.2.0. Updated 2021-04-21.
+For version 0.2.0. Updated 2021-04-22.
 
 ## Basics
 
@@ -101,9 +101,10 @@ The low parts are the lowest `w ≈ log2(n) - log2(m)` bits of each integer, wit
 They are stored in an integer vector of length `m` and width `w`.
 
 The high part of integer `x` is `x >> w`.
-A bitvector encodes the number of integers with each value of the high part in unary.
-For each value of the high part shared by `k >= 0` integers, in sorted order, the bitvector contains a sequence of `1`s of length `k` followed by `0`.
-There may be further `0`s corresponding to unused high parts.
+The integers are placed into buckets by the high part.
+A bitvector encodes the number of integers in each bucket in unary.
+For each bucket with `k >= 0` integers, in sorted order, the bitvector contains a sequence of `1`s of length `k` followed by `0`.
+There must be a bucket for each position in the semiopen interval `0..n` but no additional buckets after them.
 
 The `i`th item in the sorted vector of integers is `low[i] + ((high.select(i) - i) << w)`.
 

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -11,7 +11,8 @@
 //! Let `w = log(n) - log(m)`.
 //! In the integer array interpretation (see [`BitVec`]), we split each value into the low `w` bits and the high `log(m)` bits.
 //! The low bits are stored explicitly in an [`IntVector`].
-//! The high bits are encoded in unary in a [`BitVector`].
+//! The values are placed into buckets by the high bits.
+//! A [`BitVector`] encodes the number of values in each bucket in unary.
 //! If there are `k >= 0` values with the same high part, the bitvector will contain `k` set bits followed by an unset bit.
 //! Then
 //!
@@ -281,7 +282,13 @@ impl SparseBuilder {
         if log_m == log_n {
             log_m -= 1;
         }
-        (log_n - log_m, ones + (1usize << log_m))
+
+        let low_width = log_n - log_m;
+        let mut buckets = universe >> low_width;
+        if universe & (bits::low_set(low_width) as usize) != 0 {
+            buckets += 1;
+        }
+        (low_width, ones + buckets)
     }
 
     /// Returns the number of bits that have already been set.

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -280,7 +280,7 @@ impl SparseBuilder {
         let mut low_width: usize = 1;
         if ones > 0 {
             let ideal_width = ((universe as f64 * 2.0_f64.ln()) / (ones as f64)).log2();
-            low_width = cmp::max(ideal_width.round() as usize, 1);
+            low_width = ideal_width.max(1.0).round() as usize;
         }
 
         let mut buckets = universe >> low_width;

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -277,17 +277,17 @@ impl SparseBuilder {
 
     // Returns `(low.width(), high.len())`.
     fn get_params(universe: usize, ones: usize) -> (usize, usize) {
-        let log_n = bits::bit_len(universe as u64);
-        let mut log_m = bits::bit_len(ones as u64);
-        if log_m == log_n {
-            log_m -= 1;
+        let mut low_width: usize = 1;
+        if ones > 0 {
+            let ideal_width = ((universe as f64 * 2.0_f64.ln()) / (ones as f64)).log2();
+            low_width = cmp::max(ideal_width.round() as usize, 1);
         }
 
-        let low_width = log_n - log_m;
         let mut buckets = universe >> low_width;
         if universe & (bits::low_set(low_width) as usize) != 0 {
             buckets += 1;
         }
+
         (low_width, ones + buckets)
     }
 


### PR DESCRIPTION
Like SDSL, simple-sds used to create `1 << log2(m)` buckets for the high parts of the values in `SparseVector`. This often created unnecessary buckets for positions that did not exist in the bitvector. After this PR, there will only be buckets for positions `0` (inclusive) to `n` (exclusive), which may reduce the size of the structure significantly.

The width of the low parts also used a poor approximation inherited from SDSL: `ceil(log2(n + 1)) - ceil(log2(m + 1))`. Now the implementation rounds the optimal value `log2((n * ln(2)) / m)` to the nearest integer.