### PR TITLE
Multiset semantics for SparseVector

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
 
 * `TupleVector`: A bit-packed vector of tuples of unsigned integers, with a fixed width for each field in the tuple. Implemented on top of `RawVector`.
 * Mutable memory-mapped vectors.
+* Trait `Iterable`: The vector has a read-only iterator.
 
 ### Bitvectors
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
 
 ### Bitvectors
 
-* Multiset support for `SparseVector`.
 * `select_zero()` for `SparseVector`?
 * Versions of `predecessor()` and `successor()` that return values instead of iterators?
 * Slice-like functionality based on iterators?

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
 
 * `TupleVector`: A bit-packed vector of tuples of unsigned integers, with a fixed width for each field in the tuple. Implemented on top of `RawVector`.
 * Mutable memory-mapped vectors.
-* Trait `Iterable`: The vector has a read-only iterator.
 
 ### Bitvectors
 

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -8,7 +8,7 @@ use crate::serialize::Serialize;
 use crate::bits;
 
 use std::io::{Error, ErrorKind};
-use std::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, FromIterator};
+use std::iter::{FusedIterator, FromIterator};
 use std::{io, marker};
 
 pub mod rank_support;

--- a/src/bit_vector/select_support.rs
+++ b/src/bit_vector/select_support.rs
@@ -28,7 +28,7 @@
 
 use crate::bit_vector::{BitVector, Transformation};
 use crate::int_vector::IntVector;
-use crate::ops::{Element, Resize, Pack, Access, Push, BitVec};
+use crate::ops::{Vector, Resize, Pack, Access, Push, BitVec};
 use crate::serialize::Serialize;
 use crate::bits;
 

--- a/src/bit_vector/tests.rs
+++ b/src/bit_vector/tests.rs
@@ -4,7 +4,6 @@ use crate::raw_vector::{RawVector, AccessRaw, PushRaw};
 use crate::serialize::Serialize;
 use crate::serialize;
 
-use std::iter::{DoubleEndedIterator, ExactSizeIterator};
 use std::{cmp, fs};
 
 use rand::distributions::{Bernoulli, Distribution};

--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -6,7 +6,7 @@ use crate::serialize::{MemoryMap, MemoryMapped, Serialize};
 use crate::bits;
 
 use std::io::{Error, ErrorKind};
-use std::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, FromIterator, Extend};
+use std::iter::{FusedIterator, FromIterator};
 use std::path::Path;
 use std::io;
 

--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -115,7 +115,7 @@ impl IntVector {
     ///
     /// # Arguments
     ///
-    /// * `capacity`: Minimun capacity of the vector in elements.
+    /// * `capacity`: Minimum capacity of the vector in elements.
     /// * `width`: Width of each element in bits.
     ///
     /// # Examples
@@ -143,6 +143,28 @@ impl IntVector {
                 data: RawVector::with_capacity(capacity * width),
             })
         }
+    }
+
+    /// Returns the size of a serialized vector with the given parameters in [`u64`] elements.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity`: Minimum capacity of the vector in elements.
+    /// * `width`: Width of each element in bits.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use simple_sds::int_vector::IntVector;
+    ///
+    /// assert_eq!(IntVector::size_by_params(12, 31), 10);
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// May panic if the vector would exceed the maximum length.
+    pub fn size_by_params(capacity: usize, width: usize) -> usize {
+        2 + RawVector::size_by_params(capacity * width)
     }
 
     /// Returns an iterator visiting all elements of the vector in order.

--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -1,6 +1,6 @@
 //! A bit-packed integer vector storing fixed-width integers.
 
-use crate::ops::{Element, Resize, Pack, Access, Push, Pop};
+use crate::ops::{Vector, Resize, Pack, Access, Push, Pop};
 use crate::raw_vector::{RawVector, RawVectorMapper, RawVectorWriter, AccessRaw, PushRaw, PopRaw};
 use crate::serialize::{MemoryMap, MemoryMapped, Serialize};
 use crate::bits;
@@ -18,14 +18,14 @@ mod tests;
 /// A contiguous growable bit-packed array of fixed-width integers.
 ///
 /// This structure contains [`RawVector`], which is in turn contains [`Vec`].
-/// Each element consists of the lowest 1 to 64 bits of a [`u64`] value, as specified by parameter `width`.
-/// The maximum length of the vector is `usize::MAX / width` elements.
+/// Each item consists of the lowest 1 to 64 bits of a [`u64`] value, as specified by parameter `width`.
+/// The maximum length of the vector is `usize::MAX / width` items.
 ///
 /// A default constructed `IntVector` has `width == 64`.
 /// `IntVector` can be built from an iterator over [`u8`], [`u16`], [`u32`], [`u64`], or [`usize`] values.
 ///
 /// `IntVector` implements the following `simple_sds` traits:
-/// * Basic functionality: [`Element`], [`Resize`], [`Pack`]
+/// * Basic functionality: [`Vector`], [`Resize`], [`Pack`]
 /// * Queries and operations: [`Access`], [`Push`], [`Pop`]
 /// * Serialization: [`Serialize`]
 ///
@@ -48,7 +48,7 @@ impl IntVector {
     ///
     /// ```
     /// use simple_sds::int_vector::IntVector;
-    /// use simple_sds::ops::Element;
+    /// use simple_sds::ops::Vector;
     ///
     /// let v = IntVector::new(13).unwrap();
     /// assert!(v.is_empty());
@@ -73,15 +73,15 @@ impl IntVector {
     ///
     /// # Arguments
     ///
-    /// * `len`: Number of elements in the vector.
-    /// * `width`: Width of each element in bits.
+    /// * `len`: Number of items in the vector.
+    /// * `width`: Width of each item in bits.
     /// * `value`: Initialization value.
     ///
     /// # Examples
     ///
     /// ```
     /// use simple_sds::int_vector::IntVector;
-    /// use simple_sds::ops::{Element, Access};
+    /// use simple_sds::ops::{Vector, Access};
     ///
     /// let v = IntVector::with_len(4, 13, 1234).unwrap();
     /// assert_eq!(v.len(), 4);
@@ -109,20 +109,20 @@ impl IntVector {
         })
     }
 
-    /// Creates an empty vector with enough capacity for at least the specified number of elements of specified width.
+    /// Creates an empty vector with enough capacity for at least the specified number of items of specified width.
     ///
     /// Returns [`Err`] if the width is invalid.
     ///
     /// # Arguments
     ///
-    /// * `capacity`: Minimum capacity of the vector in elements.
-    /// * `width`: Width of each element in bits.
+    /// * `capacity`: Minimum capacity of the vector in items.
+    /// * `width`: Width of each item in bits.
     ///
     /// # Examples
     ///
     /// ```
     /// use simple_sds::int_vector::IntVector;
-    /// use simple_sds::ops::{Element, Resize};
+    /// use simple_sds::ops::{Vector, Resize};
     ///
     /// let v = IntVector::with_capacity(4, 13).unwrap();
     /// assert!(v.is_empty());
@@ -149,8 +149,8 @@ impl IntVector {
     ///
     /// # Arguments
     ///
-    /// * `capacity`: Minimum capacity of the vector in elements.
-    /// * `width`: Width of each element in bits.
+    /// * `capacity`: Minimum capacity of the vector in items.
+    /// * `width`: Width of each item in bits.
     ///
     /// # Examples
     ///
@@ -167,7 +167,7 @@ impl IntVector {
         2 + RawVector::size_by_params(capacity * width)
     }
 
-    /// Returns an iterator visiting all elements of the vector in order.
+    /// Returns an iterator visiting all items of the vector in order.
     ///
     /// # Examples
     ///
@@ -191,7 +191,7 @@ impl IntVector {
 
 //-----------------------------------------------------------------------------
 
-impl Element for IntVector {
+impl Vector for IntVector {
     type Item = u64;
 
     #[inline]
@@ -211,7 +211,7 @@ impl Element for IntVector {
 }
 
 impl Resize for IntVector {
-    fn resize(&mut self, new_len: usize, value: <Self as Element>::Item) {
+    fn resize(&mut self, new_len: usize, value: <Self as Vector>::Item) {
         if new_len > self.len() {
             self.reserve(new_len - self.len());
             while self.len() < new_len {
@@ -258,7 +258,7 @@ impl Pack for IntVector {
 
 impl Access for IntVector {
     #[inline]
-    fn get(&self, index: usize) -> <Self as Element>::Item {
+    fn get(&self, index: usize) -> <Self as Vector>::Item {
         assert!(index < self.len(), "Index is out of bounds");
         unsafe { self.data.int(index * self.width(), self.width()) }
     }
@@ -269,7 +269,7 @@ impl Access for IntVector {
     }
 
     #[inline]
-    fn set(&mut self, index: usize, value: <Self as Element>::Item) {
+    fn set(&mut self, index: usize, value: <Self as Vector>::Item) {
         assert!(index < self.len(), "Index is out of bounds");
         unsafe { self.data.set_int(index * self.width(), value, self.width()); }
     }
@@ -277,7 +277,7 @@ impl Access for IntVector {
 
 impl Push for IntVector {
     #[inline]
-    fn push(&mut self, value: <Self as Element>::Item) {
+    fn push(&mut self, value: <Self as Vector>::Item) {
         unsafe { self.data.push_int(value, self.width()); }
         self.len += 1;
     }    
@@ -285,7 +285,7 @@ impl Push for IntVector {
 
 impl Pop for IntVector {
     #[inline]
-    fn pop(&mut self) -> Option<<Self as Element>::Item> {
+    fn pop(&mut self) -> Option<<Self as Vector>::Item> {
         if self.len() > 0 {
             self.len -= 1;
         }
@@ -379,7 +379,7 @@ pub struct Iter<'a> {
 }
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = <IntVector as Element>::Item;
+    type Item = <IntVector as Vector>::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.next >= self.limit {
@@ -436,7 +436,7 @@ pub struct IntoIter {
 }
 
 impl Iterator for IntoIter {
-    type Item = <IntVector as Element>::Item;
+    type Item = <IntVector as Vector>::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.index >= self.parent.len() {
@@ -460,7 +460,7 @@ impl ExactSizeIterator for IntoIter {}
 impl FusedIterator for IntoIter {}
 
 impl IntoIterator for IntVector {
-    type Item = <Self as Element>::Item;
+    type Item = <Self as Vector>::Item;
     type IntoIter = IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -482,7 +482,7 @@ impl IntoIterator for IntVector {
 ///
 /// ```
 /// use simple_sds::int_vector::{IntVector, IntVectorWriter};
-/// use simple_sds::ops::{Element, Access, Push};
+/// use simple_sds::ops::{Vector, Access, Push};
 /// use simple_sds::serialize;
 /// use std::fs;
 ///
@@ -513,7 +513,7 @@ impl IntVectorWriter {
     /// # Arguments
     ///
     /// * `filename`: Name of the file.
-    /// * `width`: Width of each element in bits.
+    /// * `width`: Width of each item in bits.
     ///
     /// # Errors
     ///
@@ -542,8 +542,8 @@ impl IntVectorWriter {
     /// # Arguments
     ///
     /// * `filename`: Name of the file.
-    /// * `width`: Width of each element in bits.
-    /// * `buf_len`: Buffer size in elements.
+    /// * `width`: Width of each item in bits.
+    /// * `buf_len`: Buffer size in items.
     ///
     /// # Errors
     ///
@@ -595,7 +595,7 @@ impl IntVectorWriter {
 
 //-----------------------------------------------------------------------------
 
-impl Element for IntVectorWriter {
+impl Vector for IntVectorWriter {
     type Item = u64;
 
     #[inline]
@@ -616,7 +616,7 @@ impl Element for IntVectorWriter {
 
 impl Push for IntVectorWriter {
     #[inline]
-    fn push(&mut self, value: <Self as Element>::Item) {
+    fn push(&mut self, value: <Self as Vector>::Item) {
         unsafe { self.writer.push_int(value, self.width()); }
         self.len += 1;
     }
@@ -638,7 +638,7 @@ impl Drop for IntVectorWriter {
 ///
 /// ```
 /// use simple_sds::int_vector::{IntVector, IntVectorMapper};
-/// use simple_sds::ops::{Element, Access};
+/// use simple_sds::ops::{Vector, Access};
 /// use simple_sds::serialize::{MemoryMap, MemoryMapped, MappingMode};
 /// use simple_sds::serialize;
 /// use std::fs;
@@ -666,7 +666,7 @@ pub struct IntVectorMapper<'a> {
 }
 
 impl<'a> IntVectorMapper<'a> {
-    /// Returns an iterator visiting all elements of the vector in order.
+    /// Returns an iterator visiting all items of the vector in order.
     ///
     /// # Examples
     ///
@@ -696,7 +696,7 @@ impl<'a> IntVectorMapper<'a> {
     }
 }
 
-impl<'a> Element for IntVectorMapper<'a> {
+impl<'a> Vector for IntVectorMapper<'a> {
     type Item = u64;
 
     #[inline]
@@ -717,7 +717,7 @@ impl<'a> Element for IntVectorMapper<'a> {
 
 impl<'a> Access for IntVectorMapper<'a> {
     #[inline]
-    fn get(&self, index: usize) -> <Self as Element>::Item {
+    fn get(&self, index: usize) -> <Self as Vector>::Item {
         assert!(index < self.len(), "Index is out of bounds");
         unsafe { self.data.int(index * self.width(), self.width()) }
     }
@@ -728,7 +728,7 @@ impl<'a> Access for IntVectorMapper<'a> {
     }
 
     #[inline]
-    fn set(&mut self, _: usize, _: <Self as Element>::Item) {
+    fn set(&mut self, _: usize, _: <Self as Vector>::Item) {
         panic!("Not implemented");
     }
 }
@@ -803,7 +803,7 @@ pub struct MappedIter<'a> {
 }
 
 impl<'a> Iterator for MappedIter<'a> {
-    type Item = <IntVectorMapper<'a> as Element>::Item;
+    type Item = <IntVectorMapper<'a> as Vector>::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.next >= self.limit {
@@ -863,7 +863,7 @@ macro_rules! from_extend_int_vector {
                 let (lower_bound, _) = iter.size_hint();
                 self.reserve(lower_bound);
                 while let Some(value) = iter.next() {
-                    self.push(value as <Self as Element>::Item);
+                    self.push(value as <Self as Vector>::Item);
                 }
             }
         }
@@ -871,7 +871,7 @@ macro_rules! from_extend_int_vector {
         impl Extend<$t> for IntVectorWriter {
             fn extend<I: IntoIterator<Item = $t>>(&mut self, iter: I) {
                 for value in iter {
-                    self.push(value as <Self as Element>::Item);
+                    self.push(value as <Self as Vector>::Item);
                 }
             }
         }

--- a/src/int_vector/tests.rs
+++ b/src/int_vector/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::ops::{Element, Resize, Pack, Access, Push, Pop};
+use crate::ops::{Vector, Resize, Pack, Access, Push, Pop};
 use crate::serialize::{Serialize, MappingMode};
 use crate::serialize;
 

--- a/src/int_vector/tests.rs
+++ b/src/int_vector/tests.rs
@@ -230,6 +230,7 @@ fn serialize() {
         original.push(i * (i + 1) * (i + 2));
     }
     assert_eq!(original.size_in_bytes(), 160, "Invalid IntVector size in bytes");
+    assert_eq!(IntVector::size_by_params(original.capacity(), original.width()), original.size_in_elements(), "Invalid IntVector size estimate");
 
     let filename = serialize::temp_file_name("int-vector");
     serialize::serialize_to(&original, &filename).unwrap();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -2,12 +2,12 @@
 //!
 //! # Integer vectors
 //!
-//! * [`Element`]: Basic operations.
+//! * [`Vector`]: Basic operations.
 //! * [`Resize`]: Resizable vectors.
 //! * [`Pack`]: Space-efficiency by e.g. bit packing.
 //! * [`Access`]: Random access.
 //! * [`Push`], [`Pop`]: Stack operations.
-//! * [`SubElement`]: The elements are tuples of fixed type.
+//! * [`SubItem`]: The items are tuples of fixed type.
 //! * [`AccessSub`]: Access to individual fields in the tuples.
 //!
 //! # Bitvectors
@@ -20,12 +20,12 @@
 
 //-----------------------------------------------------------------------------
 
-/// A vector that contains elements of a fixed type.
+/// A vector that contains items of a fixed type.
 ///
 /// # Examples
 ///
 /// ```
-/// use simple_sds::ops::{Element, Resize, Pack, Access};
+/// use simple_sds::ops::{Vector, Resize, Pack, Access};
 /// use simple_sds::bits;
 ///
 /// #[derive(Clone, Debug, PartialEq, Eq)]
@@ -37,7 +37,7 @@
 ///     }
 /// }
 ///
-/// impl Element for Example {
+/// impl Vector for Example {
 ///     type Item = u8;
 ///
 ///     fn len(&self) -> usize {
@@ -90,7 +90,7 @@
 ///     }
 /// }
 ///
-/// // Element
+/// // Vector
 /// let mut v = Example::new();
 /// assert!(v.is_empty());
 /// assert_eq!(v.len(), 0);
@@ -117,11 +117,11 @@
 ///     assert_eq!(v.get(i), i as u8);
 /// }
 /// ```
-pub trait Element {
-    /// The type of the elements in the vector.
+pub trait Vector {
+    /// The type of the items in the vector.
     type Item;
 
-    /// Returns the number of elements in the vector.
+    /// Returns the number of items in the vector.
     fn len(&self) -> usize;
 
     /// Returns `true` if the vector is empty.
@@ -129,7 +129,7 @@ pub trait Element {
         self.len() == 0
     }
 
-    /// Returns the width of of an element in bits.
+    /// Returns the width of of an item in bits.
     fn width(&self) -> usize;
 
     /// Returns the maximum length of the vector.
@@ -138,8 +138,8 @@ pub trait Element {
 
 /// A vector that can be resized.
 ///
-/// See [`Element`] for an example.
-pub trait Resize: Element {
+/// See [`Vector`] for an example.
+pub trait Resize: Vector {
     /// Resizes the vector to a specified length.
     ///
     /// If `new_len > self.len()`, the new `new_len - self.len()` values will be initialized.
@@ -153,15 +153,15 @@ pub trait Resize: Element {
     /// # Panics
     ///
     /// May panic if the length would exceed the maximum length.
-    fn resize(&mut self, new_len: usize, value: <Self as Element>::Item);
+    fn resize(&mut self, new_len: usize, value: <Self as Vector>::Item);
 
     /// Clears the vector without freeing the data.
     fn clear(&mut self);
 
-    /// Returns the number of elements that the vector can store without reallocations.
+    /// Returns the number of items that the vector can store without reallocations.
     fn capacity(&self) -> usize;
 
-    /// Reserves space for storing at least `self.len() + additional` elements in the vector.
+    /// Reserves space for storing at least `self.len() + additional` items in the vector.
     ///
     /// Does nothing if the capacity is already sufficient.
     ///
@@ -173,59 +173,59 @@ pub trait Resize: Element {
 
 /// Store the vector more space-efficiently.
 ///
-/// This may, for example, reduce the width of an element.
+/// This may, for example, reduce the width of an item.
 ///
-/// See [`Element`] for an example.
-pub trait Pack: Element {
-    /// Try to store the elements of the vector more space-efficiently.
+/// See [`Vector`] for an example.
+pub trait Pack: Vector {
+    /// Try to store the items of the vector more space-efficiently.
     fn pack(&mut self);
 }
 
 //-----------------------------------------------------------------------------
 
-/// A vector that supports random access to its elements.
+/// A vector that supports random access to its items.
 ///
-/// See [`Element`] for an example.
-pub trait Access: Element {
-    /// Gets an element from the vector.
+/// See [`Vector`] for an example.
+pub trait Access: Vector {
+    /// Gets an item from the vector.
     ///
     /// # Panics
     ///
     /// May panic if `index` is not a valid index in the vector.
     /// May panic from I/O errors.
-    fn get(&self, index: usize) -> <Self as Element>::Item;
+    fn get(&self, index: usize) -> <Self as Vector>::Item;
 
     /// Returns `true` if the underlying data is mutable.
     ///
     /// This is relevant, for example, with memory-mapped vectors, where the underlying file may be opened as read-only.
     fn is_mutable(&self) -> bool;
 
-    /// Sets an element in the vector.
+    /// Sets an item in the vector.
     ///
     ///
     /// # Arguments
     ///
     /// * `index`: Index in the vector.
-    /// * `value`: New value of the element.
+    /// * `value`: New value of the item.
     ///
     /// # Panics
     ///
     /// May panic if `index` is not a valid index in the vector.
     /// May panic if the underlying data is not mutable.
     /// May panic from I/O errors.
-    fn set(&mut self, index: usize, value: <Self as Element>::Item);
+    fn set(&mut self, index: usize, value: <Self as Vector>::Item);
 }
 
 //-----------------------------------------------------------------------------
 
-/// Append elements to a vector.
+/// Append items to a vector.
 ///
 /// [`Pop`] is a separate trait, because a file writer may not implement it.
 ///
 /// # Examples
 ///
 /// ```
-/// use simple_sds::ops::{Element, Push, Pop};
+/// use simple_sds::ops::{Vector, Push, Pop};
 ///
 /// struct Example(Vec<u8>);
 ///
@@ -235,7 +235,7 @@ pub trait Access: Element {
 ///     }
 /// }
 ///
-/// impl Element for Example {
+/// impl Vector for Example {
 ///     type Item = u8;
 ///
 ///     fn len(&self) -> usize {
@@ -278,38 +278,39 @@ pub trait Access: Element {
 /// assert_eq!(v.pop(), None);
 /// assert!(v.is_empty());
 /// ```
-pub trait Push: Element {
-    /// Appends an element to the vector.
+pub trait Push: Vector {
+    /// Appends an item to the vector.
     ///
     /// # Panics
     ///
     /// May panic from I/O errors.
     /// May panic if the vector would exceed the maximum length.
-    fn push(&mut self, value: <Self as Element>::Item);
+    fn push(&mut self, value: <Self as Vector>::Item);
 }
 
-/// Remove and return top elements from a vector.
+/// Remove and return top items from a vector.
 ///
 /// [`Push`] is a separate trait, because a file writer may not implement `Pop`.
 ///
 /// See [`Push`] for an example.
-pub trait Pop: Element {
-    /// Removes and returns the last element from the vector.
-    /// Returns [`None`] if there are no more elements in the vector.
-    fn pop(&mut self) -> Option<<Self as Element>::Item>;
+pub trait Pop: Vector {
+    /// Removes and returns the last item from the vector.
+    ///
+    /// Returns [`None`] if there are no more items in the vector.
+    fn pop(&mut self) -> Option<<Self as Vector>::Item>;
 }
 
 //-----------------------------------------------------------------------------
 
-/// A vector that contains elements with a fixed number of subelements of a fixed type in each element.
+/// A vector that contains items with a fixed number of subitems of a fixed type in each item.
 ///
-/// Term *index* refers to the location of an element within a vector, while *offset* refers to the location of a subelement within an element.
-/// Every subelement at the same offset has the same width in bits.
+/// Term *index* refers to the location of an item within a vector, while *offset* refers to the location of a subitem within an item.
+/// Every subitem at the same offset has the same width in bits.
 ///
 /// # Examples
 ///
 /// ```
-/// use simple_sds::ops::{Element, SubElement, AccessSub};
+/// use simple_sds::ops::{Vector, SubItem, AccessSub};
 /// use simple_sds::bits;
 /// use std::mem;
 ///
@@ -321,7 +322,7 @@ pub trait Pop: Element {
 ///     }
 /// }
 ///
-/// impl Element for Example {
+/// impl Vector for Example {
 ///     type Item = [u8; 8];
 ///
 ///     fn len(&self) -> usize {
@@ -337,10 +338,10 @@ pub trait Pop: Element {
 ///     }
 /// } 
 ///
-/// impl SubElement for Example {
+/// impl SubItem for Example {
 ///     type SubItem = u8;
 ///
-///     fn element_len(&self) -> usize {
+///     fn item_len(&self) -> usize {
 ///         8
 ///     }
 ///
@@ -359,10 +360,10 @@ pub trait Pop: Element {
 ///     }
 /// }
 ///
-/// // SubElement
+/// // SubItem
 /// let v = Example::new();
 /// assert!(v.is_empty());
-/// assert_eq!(v.element_len(), mem::size_of::<<Example as Element>::Item>());
+/// assert_eq!(v.item_len(), mem::size_of::<<Example as Vector>::Item>());
 /// for i in 0..v.len() {
 ///     assert_eq!(v.sub_width(i), bits::bit_len(u8::MAX as u64));
 /// }
@@ -376,52 +377,52 @@ pub trait Pop: Element {
 /// v.set_sub(1, 3, 55u8);
 /// assert_eq!(v.sub(1, 3), 55u8);
 /// ```
-pub trait SubElement: Element {
-    /// The type of the subelements of an element.
+pub trait SubItem: Vector {
+    /// The type of the subitems of an item.
     type SubItem;
 
-    /// Returns the number of subelements in an element.
-    fn element_len(&self) -> usize;
+    /// Returns the number of subitems in an item.
+    fn item_len(&self) -> usize;
 
-    /// Returns the width of the specified subelement in bits.
+    /// Returns the width of the specified subitem in bits.
     ///
     /// # Panics
     ///
-    /// May panic if `offset >= self.element_len()`.
+    /// May panic if `offset >= self.item_len()`.
     fn sub_width(&self, offset: usize) -> usize;
 }
 
-/// A vector that supports random access to the subelements of its elements.
+/// A vector that supports random access to the subitems of its items.
 ///
-/// See [`SubElement`] for an example.
-pub trait AccessSub: SubElement {
-    /// Gets a subelement from the vector.
+/// See [`SubItem`] for an example.
+pub trait AccessSub: SubItem {
+    /// Gets a subitem from the vector.
     ///
     /// # Arguments
     ///
     /// * `index`: Index in the vector.
-    /// * `offset`: Offset in the element.
+    /// * `offset`: Offset in the item.
     ///
     /// # Panics
     ///
-    /// May panic if `index` is not a valid index in the vector or `offset` is not a valid offset in the element.
+    /// May panic if `index` is not a valid index in the vector or `offset` is not a valid offset in the item.
     /// May panic from I/O errors.
-    fn sub(&self, index: usize, offset: usize) -> <Self as SubElement>::SubItem;
+    fn sub(&self, index: usize, offset: usize) -> <Self as SubItem>::SubItem;
 
-    /// Sets a subelement in the vector.
+    /// Sets a subitem in the vector.
     ///
     /// # Arguments
     ///
     /// * `index`: Index in the vector.
-    /// * `offset`: Offset in the element.
-    /// * `value`: New value of the subelement.
+    /// * `offset`: Offset in the item.
+    /// * `value`: New value of the subitem.
     ///
     /// # Panics
     ///
-    /// May panic if `index` is not a valid index in the vector or `offset` is not a valid offset in the element.
+    /// May panic if `index` is not a valid index in the vector or `offset` is not a valid offset in the item.
     /// May panic if the underlying data is not mutable.
     /// May panic from I/O errors.
-    fn set_sub(&mut self, index: usize, offset: usize, value: <Self as SubElement>::SubItem);
+    fn set_sub(&mut self, index: usize, offset: usize, value: <Self as SubItem>::SubItem);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/raw_vector.rs
+++ b/src/raw_vector.rs
@@ -383,6 +383,19 @@ impl RawVector {
         }
     }
 
+    /// Returns the size of a serialized vector with the given capacity in [`u64`] elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use simple_sds::raw_vector::RawVector;
+    ///
+    /// assert_eq!(RawVector::size_by_params(247), 6);
+    /// ```
+    pub fn size_by_params(capacity: usize) -> usize {
+        2 + bits::bits_to_words(capacity)
+    }
+
     /// Returns a copy of the vector with each bit flipped.
     ///
     /// # Examples

--- a/src/raw_vector/tests.rs
+++ b/src/raw_vector/tests.rs
@@ -217,6 +217,7 @@ fn serialize() {
         unsafe { original.push_int(i * (i + 1) * (i + 2), 16); }
     }
     assert_eq!(original.size_in_bytes(), 144, "Invalid RawVector size in bytes");
+    assert_eq!(RawVector::size_by_params(original.capacity()), original.size_in_elements(), "Invalid RawVector size estimate");
 
     let filename = serialize::temp_file_name("raw-vector");
     serialize::serialize_to(&original, &filename).unwrap();

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -67,6 +67,9 @@ mod tests;
 ///
 /// `self.size_in_elements()` should always be nonzero.
 ///
+/// A structure that implements `Serialize` may also have an associated function `size_by_params`.
+/// The function determines the size of a serialized structure with the given parameters in [`u64`] elements without building the structure.
+///
 /// # Examples
 ///
 /// ```
@@ -149,12 +152,12 @@ pub trait Serialize: Sized {
 
     /// Returns the size of the serialized struct in [`u64`] elements.
     ///
-    /// This should be closely related to the size of the in-memory struct.
+    /// This is usually closely related to the size of the in-memory struct.
     fn size_in_elements(&self) -> usize;
 
     /// Returns the size of the serialized struct in bytes.
     ///
-    /// This should be closely related to the size of the in-memory struct.
+    /// This is usually closely related to the size of the in-memory struct.
     fn size_in_bytes(&self) -> usize {
         bits::words_to_bytes(self.size_in_elements())
     }

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -34,7 +34,7 @@ use crate::bits;
 
 use std::convert::TryFrom;
 use std::io::{Error, ErrorKind};
-use std::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Extend};
+use std::iter::FusedIterator;
 use std::{cmp, io};
 
 #[cfg(test)]

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -24,6 +24,9 @@
 //! > `select(i) = low[i] + ((high.select(i) - i) << w)`.
 //!
 //! Rank, predecessor, and successor queries use `select_zero` on `high` followed by a linear scan.
+//!
+//! We can also support multisets that contain duplicate values (in the integer array interpretation).
+//! Rank queries for unset bits do not work correctly with multisets.
 
 use crate::bit_vector::BitVector;
 use crate::int_vector::IntVector;
@@ -50,7 +53,12 @@ mod tests;
 /// The maximum length of the vector is approximately [`usize::MAX`] bits.
 ///
 /// Conversions between `SparseVector` and [`BitVector`] are possible using the [`From`] trait.
-/// 
+///
+/// `SparseVector` supports partial multiset semantics.
+/// A multiset bitvector is one that contains duplicate values in the integer array interpretation.
+/// Queries that operate on present values work correctly with a multiset, while [`Rank::rank_zero`] does not.
+/// Multiset vectors can be built with [`SparseBuilder::multiset`] and [`SparseVector::try_from_iter`].
+///
 /// `SparseVector` implements the following `simple_sds` traits:
 /// * Basic functionality: [`BitVec`]
 /// * Queries and operations: [`Rank`], [`Select`], [`PredSucc`]
@@ -146,6 +154,7 @@ impl SparseVector {
     /// let sv = SparseVector::copy_bit_vec(&bv);
     /// assert_eq!(sv.len(), bv.len());
     /// assert_eq!(sv.count_ones(), bv.count_ones());
+    /// assert!(!sv.is_multiset());
     /// ```
     pub fn copy_bit_vec<'a, T: BitVec<'a> + Select<'a>>(source: &'a T) -> SparseVector {
         let mut builder = SparseBuilder::new(source.len(), source.count_ones()).unwrap();
@@ -153,6 +162,56 @@ impl SparseVector {
             unsafe { builder.set_unchecked(index); }
         }
         SparseVector::try_from(builder).unwrap()
+    }
+
+    // FIXME tests
+    /// Builds a vector from the values in the iterator using multiset semantics.
+    ///
+    /// Returns an error message if the values are not sorted.
+    /// Universe size is set to be barely large enough for the values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use simple_sds::sparse_vector::SparseVector;
+    /// use simple_sds::ops::{BitVec, Select};
+    ///
+    /// let source: Vec<usize> = vec![3, 4, 4, 7, 11, 19];
+    /// let sv = SparseVector::try_from_iter(source.iter().cloned()).unwrap();
+    /// assert_eq!(sv.len(), 20);
+    /// assert_eq!(sv.count_ones(), source.len());
+    /// assert!(sv.is_multiset());
+    ///
+    /// for (index, value) in sv.one_iter() {
+    ///     assert_eq!(value, source[index]);
+    /// }
+    /// ```
+    pub fn try_from_iter<T: Iterator<Item = usize> + DoubleEndedIterator + ExactSizeIterator>(iter: T) -> Result<SparseVector, &'static str> {
+        let mut iter = iter;
+        let (ones, _) = iter.size_hint();
+        let universe = if let Some(pos) = iter.next_back() { pos + 1 } else { 0 };
+        let mut builder = SparseBuilder::multiset(universe, ones);
+        for pos in iter {
+            builder.try_set(pos)?;
+        }
+        if universe > 0 {
+            builder.try_set(universe - 1)?;
+        }
+        SparseVector::try_from(builder)
+    }
+
+    /// Returns `true` if the vector is a multiset (contains duplicate values).
+    ///
+    /// This method is somewhat expensive, as it iterates over the vector.
+    pub fn is_multiset(&self) -> bool {
+        let mut prev = self.len();
+        for (_, value) in self.one_iter() {
+            if value == prev {
+                return true;
+            }
+            prev = value;
+        }
+        return false;
     }
 
     // Split a bitvector index into high and low parts.
@@ -219,6 +278,7 @@ impl SparseVector {
 /// assert_eq!(builder.universe(), 300);
 /// assert_eq!(builder.next_index(), 0);
 /// assert!(!builder.is_full());
+/// assert!(!builder.is_multiset());
 ///
 /// builder.set(12);
 /// assert_eq!(builder.len(), 1);
@@ -247,10 +307,12 @@ pub struct SparseBuilder {
     len: usize,
     // The first index that can be set.
     next: usize,
+    // `0` if we are building a multiset, `1` if not.
+    increment: usize,
 }
 
 impl SparseBuilder {
-    /// Returns an empty SparseBuilder.
+    /// Returns an empty SparseBuilder without multiset semantics.
     ///
     /// Returns [`Err`] if `ones > universe`.
     ///
@@ -277,13 +339,69 @@ impl SparseBuilder {
             high: high,
             len: 0,
             next: 0,
+            increment: 1,
         })
     }
 
-    // Returns `(low.width(), high.len())`.
+    // FIXME tests
+    /// Returns an empty SparseBuilder with multiset semantics.
+    ///
+    /// # Arguments
+    ///
+    /// * `universe`: Universe size or length of the bitvector.
+    /// * `ones`: Number of bits that will be set in the bitvector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use simple_sds::ops::BitVec;
+    /// use simple_sds::sparse_vector::{SparseVector, SparseBuilder};
+    /// use std::convert::TryFrom;
+    ///
+    /// let mut builder = SparseBuilder::multiset(120, 3);
+    /// assert_eq!(builder.capacity(), 3);
+    /// assert_eq!(builder.universe(), 120);
+    /// assert!(builder.is_multiset());
+    ///
+    /// builder.set(12);
+    /// builder.set(24);
+    /// builder.set(24);
+    /// assert!(builder.is_full());
+    ///
+    /// let sv = SparseVector::try_from(builder).unwrap();
+    /// assert_eq!(sv.len(), 120);
+    /// assert_eq!(sv.count_ones(), 3);
+    /// assert!(sv.is_multiset());
+    /// ```
+    pub fn multiset(universe: usize, ones: usize) -> SparseBuilder {
+        let (width, high_len) = Self::get_params(universe, ones);
+        let low = IntVector::with_len(ones, width, 0).unwrap();
+        let data = SparseVector {
+            len: universe,
+            high: BitVector::from(RawVector::new()),
+            low: low,
+        };
+
+        let high = RawVector::with_len(high_len, false);
+        SparseBuilder {
+            data: data,
+            high: high,
+            len: 0,
+            next: 0,
+            increment: 0,
+        }
+    }
+
+    // FIXME tests
+    /// Returns `true` if the builder is using multiset semantics.
+    pub fn is_multiset(&self) -> bool {
+        self.increment == 0
+    }
+
+    // Returns `(low.width(), high.len())`. Now works with overfull multisets as well.
     fn get_params(universe: usize, ones: usize) -> (usize, usize) {
         let mut low_width: usize = 1;
-        if ones > 0 {
+        if ones > 0 && ones <= universe {
             let ideal_width = ((universe as f64 * 2.0_f64.ln()) / (ones as f64)).log2();
             low_width = ideal_width.max(1.0).round() as usize;
         }
@@ -341,7 +459,7 @@ impl SparseBuilder {
         let parts = self.data.split(index);
         self.high.set_bit(parts.high + self.len, true);
         self.data.low.set(self.len, parts.low as u64);
-        self.len += 1; self.next = index + 1;
+        self.len += 1; self.next = index + self.increment;
     }
 
     /// Tries to set the specified bit in the bitvector.
@@ -352,7 +470,11 @@ impl SparseBuilder {
             return Err("The builder is full");
         }
         if index < self.next_index() {
-            return Err("Index must be past the previous set bit");
+            if self.increment == 0 {
+                return Err("Index must be >= previous set position");
+            } else {
+                return Err("Index must be > previous set position");
+            }
         }
         if index >= self.universe() {
             return Err("Index is larger than universe size");
@@ -857,15 +979,15 @@ impl From<SparseVector> for BitVector {
 impl TryFrom<SparseBuilder> for SparseVector {
     type Error = &'static str;
 
-    fn try_from(value: SparseBuilder) -> Result<Self, Self::Error> {
-        let mut value = value;
-        if !value.is_full() {
+    fn try_from(builder: SparseBuilder) -> Result<Self, Self::Error> {
+        let mut builder = builder;
+        if !builder.is_full() {
             return Err("The builder is not full");
         }
-        value.data.high = BitVector::from(value.high);
-        value.data.high.enable_select();
-        value.data.high.enable_select_zero();
-        Ok(value.data)
+        builder.data.high = BitVector::from(builder.high);
+        builder.data.high.enable_select();
+        builder.data.high.enable_select_zero();
+        Ok(builder.data)
     }
 }
 

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -27,7 +27,7 @@
 
 use crate::bit_vector::BitVector;
 use crate::int_vector::IntVector;
-use crate::ops::{Element, Access, BitVec, Rank, Select, PredSucc, SelectZero};
+use crate::ops::{Vector, Access, BitVec, Rank, Select, PredSucc, SelectZero};
 use crate::raw_vector::{RawVector, AccessRaw};
 use crate::serialize::Serialize;
 use crate::bits;


### PR DESCRIPTION
`SparseVector` now supports multisets (sorted integer vectors with duplicate values). They can be built with `SparseBuilder::multiset` or with `SparseVector::try_from_iter`. Operations over all bits and set bits work but `rank_zero` does not. This is similar to the multiset `sd_vector` in the [vgteam fork of SDSL](https://github.com/vgteam/sdsl-lite).

Also, because there was some confusion between vector elements and serialization elements, `Element` trait became `Vector` and vectors now have items instead of elements.