### PR TITLE
select_zero() for SparseVector

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020, 2021 Jouni Siren
+Copyright (c) 2020, 2021, 2022 Jouni Siren
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
   * Iterators over set bits, unset bits, and all bits.
   * Implemented on top of `RawVector`.
 * `SparseVector`: An Elias-Fano encoded bitvector.
-  * Supports `rank()`, `rank_zero()`, `select()`, `predecessor()`, and `successor()` queries .
+  * Supports `rank()`, `rank_zero()`, `select()`, `select_zero()`, `predecessor()`, and `successor()` queries .
   * Iterators over set bits and all bits.
   * Space-efficient construction with `SparseBuilder`.
 
@@ -34,7 +34,6 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
 
 ### Bitvectors
 
-* `select_zero()` for `SparseVector`?
 * Versions of `predecessor()` and `successor()` that return values instead of iterators?
 * Slice-like functionality based on iterators?
 

--- a/src/bin/benchmark/utils.rs
+++ b/src/bin/benchmark/utils.rs
@@ -2,7 +2,6 @@ use simple_sds::bit_vector::BitVector;
 use simple_sds::ops::BitVec;
 use simple_sds::raw_vector::{RawVector, PushRaw};
 use simple_sds::serialize::Serialize;
-use simple_sds::bits;
 
 use std::time::Duration;
 
@@ -38,25 +37,36 @@ pub fn random_vector(len: usize, density: f64) -> BitVector {
     bv
 }
 
-pub fn generate_rank_queries(n: usize, bit_len: usize) -> Vec<usize> {
-    let len = 1usize << bit_len;
-    let mut result: Vec<usize> = Vec::with_capacity(len);
+pub fn generate_rank_queries(n: usize, len: usize) -> Vec<usize> {
+    let mut result: Vec<usize> = Vec::with_capacity(n);
 
     let mut rng = rand::thread_rng();
     for _ in 0..n {
-        let value = rng.gen::<u64>() & bits::low_set(bit_len);
-        result.push(value as usize);
+        let value = rng.gen::<usize>() % len;
+        result.push(value);
     }
 
     result
 }
 
 pub fn generate_select_queries(n: usize, ones: usize) -> Vec<usize> {
-    let mut result: Vec<usize> = Vec::with_capacity(ones);
+    let mut result: Vec<usize> = Vec::with_capacity(n);
 
     let mut rng = rand::thread_rng();
     for _ in 0..n {
         let value = rng.gen::<usize>() % ones;
+        result.push(value);
+    }
+
+    result
+}
+
+pub fn generate_select_zero_queries(n: usize, zeros: usize) -> Vec<usize> {
+    let mut result: Vec<usize> = Vec::with_capacity(n);
+
+    let mut rng = rand::thread_rng();
+    for _ in 0..n {
+        let value = rng.gen::<usize>() % zeros;
         result.push(value);
     }
 

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -327,7 +327,7 @@ impl Transformation for Complement {
 
     #[inline]
     fn count_ones(parent: &BitVector) -> usize {
-        parent.len() - parent.count_ones()
+        parent.count_zeros()
     }
 
     fn one_iter(parent: &BitVector) -> OneIter<'_, Self> {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -651,6 +651,7 @@ pub trait AccessSub: SubItem {
 /// assert_eq!(bv.len(), 137);
 /// assert!(!bv.is_empty());
 /// assert_eq!(bv.count_ones(), 4);
+/// assert_eq!(bv.count_zeros(), 133);
 /// assert!(bv.get(33));
 /// assert!(!bv.get(34));
 /// for (index, value) in bv.iter().enumerate() {
@@ -701,6 +702,12 @@ pub trait BitVec<'a> {
     ///
     /// Because the vector is immutable, the implementation should cache the value during construction.
     fn count_ones(&self) -> usize;
+
+    /// Returns the number of zeros in the bit array.
+    #[inline]
+    fn count_zeros(&self) -> usize {
+        self.len() - self.count_ones()
+    }
 
     /// Reads a bit from the bit array.
     ///

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -259,8 +259,7 @@ impl Serialize for Vec<u8> {
 
     fn load<T: Read>(reader: &mut T) -> io::Result<Self> {
         let size = usize::load(reader)?;
-        let mut value: Vec<u8> = Vec::with_capacity(size);
-        unsafe { value.set_len(size); }
+        let mut value: Vec<u8> = vec![0; size];
         reader.read_exact(value.as_mut_slice())?;
 
         // Skip padding.

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -224,18 +224,6 @@ impl SparseVector {
         false
     }
 
-    // FIXME Move to BitVec
-    /// Counts the number of unset bits in the bitvector.
-    ///
-    /// The value will be a lower bound if the vector is a multiset.
-    pub fn count_zeros(&self) -> usize {
-        if self.count_ones() >= self.len() {
-            0
-        } else {
-            self.len() - self.count_ones()
-        }
-    }
-
     // Split a bitvector index into high and low parts.
     fn split(&self, index: usize) -> Parts {
         Parts {
@@ -666,6 +654,16 @@ impl<'a> BitVec<'a> for SparseVector {
     #[inline]
     fn count_ones(&self) -> usize {
         self.low.len()
+    }
+
+    // Override the default implementation, because it may underflow with multisets.
+    #[inline]
+    fn count_zeros(&self) -> usize {
+        if self.count_ones() >= self.len() {
+            0
+        } else {
+            self.len() - self.count_ones()
+        }
     }
 
     fn get(&self, index: usize) -> bool {

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -148,6 +148,9 @@ struct Parts {
 }
 
 impl SparseVector {
+    // Stop binary search in `select_zero` when there are at most this many runs left.
+    const BINARY_SEARCH_THRESHOLD: usize = 24;
+
     /// Returns a copy of the source bitvector as `SparseVector`.
     ///
     /// The copy is created by iterating over the set bits using [`Select::one_iter`].
@@ -270,8 +273,7 @@ impl SparseVector {
         let mut result = (0, self.one_iter());
 
         // Invariant: `self.rank_zero(high) > rank`.
-        // FIXME use a symbolic constant
-        while high - low > 32 {
+        while high - low > Self::BINARY_SEARCH_THRESHOLD {
             let mid = low + (high - low) / 2;
             let mut iter = self.select_iter(mid);
             let (_, mid_pos) = iter.next().unwrap();

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -149,7 +149,7 @@ struct Parts {
 
 impl SparseVector {
     // Stop binary search in `select_zero` when there are at most this many runs left.
-    const BINARY_SEARCH_THRESHOLD: usize = 24;
+    const BINARY_SEARCH_THRESHOLD: usize = 16;
 
     /// Returns a copy of the source bitvector as `SparseVector`.
     ///


### PR DESCRIPTION
Add `select_zero()` support for `SparseVector` using binary search with `select()`, as in SDSL. As a minor optimization, the query switches to a linear scan when there are at most 16 runs of 0s left. Caching the results of the first few iterations of the binary search would be more beneficial, but adding a new support structure would have required changes to the serialization format.

Resolves #10.