### PR TITLE
Enable build for wasm32-wasi

### DIFF
--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -1,8 +1,12 @@
 //! A bit-packed integer vector storing fixed-width integers.
 
 use crate::ops::{Vector, Resize, Pack, Access, AccessIter, Push, Pop};
-use crate::raw_vector::{RawVector, RawVectorMapper, RawVectorWriter, AccessRaw, PushRaw, PopRaw};
-use crate::serialize::{MemoryMap, MemoryMapped, Serialize};
+use crate::raw_vector::{RawVector, RawVectorWriter, AccessRaw, PushRaw, PopRaw};
+#[cfg(not(target_family = "wasm"))]
+use crate::raw_vector::RawVectorMapper;
+use crate::serialize::Serialize;
+#[cfg(not(target_family = "wasm"))]
+use crate::serialize::{MemoryMap, MemoryMapped};
 use crate::bits;
 
 use std::io::{Error, ErrorKind};
@@ -580,6 +584,7 @@ impl Drop for IntVectorWriter {
 /// drop(mapper); drop(map);
 /// fs::remove_file(&filename).unwrap();
 /// ```
+#[cfg(not(target_family = "wasm"))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct IntVectorMapper<'a> {
     len: usize,
@@ -587,6 +592,7 @@ pub struct IntVectorMapper<'a> {
     data: RawVectorMapper<'a>,
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl<'a> Vector for IntVectorMapper<'a> {
     type Item = u64;
 
@@ -606,6 +612,7 @@ impl<'a> Vector for IntVectorMapper<'a> {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl<'a> Access<'a> for IntVectorMapper<'a> {
     type Iter = AccessIter<'a, Self>;
 
@@ -620,6 +627,7 @@ impl<'a> Access<'a> for IntVectorMapper<'a> {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl<'a> MemoryMapped<'a> for IntVectorMapper<'a> {
     fn new(map: &'a MemoryMap, offset: usize) -> io::Result<Self> {
         if offset + 1 >= map.len() {
@@ -643,6 +651,7 @@ impl<'a> MemoryMapped<'a> for IntVectorMapper<'a> {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl<'a> AsRef<RawVectorMapper<'a>> for IntVectorMapper<'a> {
     #[inline]
     fn as_ref(&self) -> &RawVectorMapper<'a> {

--- a/src/raw_vector.rs
+++ b/src/raw_vector.rs
@@ -1,6 +1,8 @@
 //! The basic vector implementing the low-level functionality used by other vectors in the crate.
 
-use crate::serialize::{MappedSlice, MemoryMap, MemoryMapped, Serialize};
+use crate::serialize::Serialize;
+#[cfg(not(target_family = "wasm"))]
+use crate::serialize::{MappedSlice, MemoryMap, MemoryMapped};
 use crate::bits;
 
 use std::fs::{File, OpenOptions};
@@ -906,12 +908,14 @@ impl Drop for RawVectorWriter {
 /// drop(mapper); drop(map);
 /// fs::remove_file(&filename);
 /// ```
+#[cfg(not(target_family = "wasm"))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct RawVectorMapper<'a> {
     len: usize,
     data: MappedSlice<'a, u64>,
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl<'a> RawVectorMapper<'a> {
     /// Returns the length of the vector in bits.
     #[inline]
@@ -935,6 +939,7 @@ impl<'a> RawVectorMapper<'a> {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl<'a> AccessRaw for RawVectorMapper<'a> {
     #[inline]
     fn bit(&self, bit_offset: usize) -> bool {
@@ -973,6 +978,7 @@ impl<'a> AccessRaw for RawVectorMapper<'a> {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl<'a> MemoryMapped<'a> for RawVectorMapper<'a> {
     fn new(map: &'a MemoryMap, offset: usize) -> io::Result<Self> {
         if offset >= map.len() {
@@ -995,6 +1001,7 @@ impl<'a> MemoryMapped<'a> for RawVectorMapper<'a> {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl<'a> AsRef<MappedSlice<'a, u64>> for RawVectorMapper<'a> {
     #[inline]
     fn as_ref(&self) -> &MappedSlice<'a, u64> {


### PR DESCRIPTION
This sets up conditional compilation to avoid building all the memory mapping stuff on WASM, where we can't memory map anything.