### PR TITLE
Run-length encoded wavelet matrix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,12 @@ readme = "README.md"
 repository = "https://github.com/jltsiren/simple-sds"
 
 [features]
-binaries = ["getopts", "rand", "rand_distr"]
+default = ["libc"]
+binaries = ["getopts", "libc", "rand", "rand_distr"]
 
 [dependencies]
 getopts = { version = "0.2", optional = true }
-libc = "0.2"
+libc = { version = "0.2", optional = true }
 rand = { version = "0.9", optional = true }
 rand_distr = { version = "0.5", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "simple-sds"
 version = "0.3.1"
-authors = ["Jouni Siren <jouni.siren@iki.fi>"]
-edition = "2018"
-description = "Basic succinct data structures."
+edition = "2024"
+description = "Basic succinct data structures"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/jltsiren/simple-sds"
@@ -14,12 +13,12 @@ binaries = ["getopts", "rand", "rand_distr"]
 [dependencies]
 getopts = { version = "0.2", optional = true }
 libc = "0.2"
-rand = { version = "0.8", optional = true }
-rand_distr = { version = "0.4", optional = true }
+rand = { version = "0.9", optional = true }
+rand_distr = { version = "0.5", optional = true }
 
 [dev-dependencies]
-rand = "0.8"
-rand_distr = "0.4"
+rand = "0.9"
+rand_distr = "0.5"
 
 [[bin]]
 name = "bv-benchmark"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020, 2021, 2022 Jouni Siren
+Copyright (c) 2020, 2021, 2022, 2023, 2024 Jouni Siren
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020, 2021, 2022, 2023, 2024 Jouni Siren
+Copyright (c) 2020, 2021, 2022, 2023, 2024, 2025 Jouni Siren
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -24,6 +24,7 @@
   * `AccessIter` is a trivial implementation of the iterator using `Access::get`.
   * `Access::get_or` returns a default value if the index is not valid.
 * `IntVector` construction from a slice of integers.
+* Memory-mapped structures are enabled with feature `libc`.
 
 ## Simple-SDS 0.3.1 (2022-02-17)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,7 @@
 ### Bitvectors
 
 * `RLVector`: Run-length encoded bitvector similar to the one in RLCSA.
+* `FullBitVec`: A marker trait indicating a fully functional bitvector.
 * Consistent conversions between bitvector types:
   * `From` trait between any two bitvector types.
   * Associated function `copy_bit_vec` for copying from a type that implements `Select`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -47,7 +47,6 @@
 ### Other
 
 * Vectors have items instead of elements to avoid confusion between vector elements and serialization elements.
-* Uses `rand` 0.8 instead of 0.7.
 * Serialization improvements:
   * `skip_option`, `absent_option`, and `absent_option_size` for dealing with optional structures.
   * `test` for running basic serialization tests for a new type.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,7 +14,8 @@
 
 * Trait `VectorIndex` for rank/select-type queries over integer vectors.
 * Implementations of `VectorIndex`:
-  * `WaveletMatrix`: Plain balanced wavelet matrix.
+  * `WaveletMatrix`: Balanced plain wavelet matrix.
+  * `RLWM`: Balanced run-length encoded wavelet matrix.
 
 ### Other
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,7 +7,7 @@
 * `RLVector`: Run-length encoded bitvector similar to the one in RLCSA.
 * `FullBitVec`: A marker trait indicating a fully functional bitvector.
 * Consistent conversions between bitvector types:
-  * `From` trait between any two bitvector types.
+  * `From` trait between any two bitvector types from both values and references.
   * Associated function `copy_bit_vec` for copying from a type that implements `Select`.
 
 ### Wavelet matrices
@@ -23,6 +23,7 @@
   * The trait includes an iterator over the values.
   * `AccessIter` is a trivial implementation of the iterator using `Access::get`.
   * `Access::get_or` returns a default value if the index is not valid.
+* `IntVector` construction from a slice of integers.
 
 ## Simple-SDS 0.3.1 (2022-02-17)
 

--- a/SERIALIZATION.md
+++ b/SERIALIZATION.md
@@ -180,9 +180,10 @@ Serialization format for the wavelet matrix core:
 1. `width`: Width of the items as an element.
 2. `levels`: A bitvector for each level in `0..width`.
 
-### Plain wavelet matrix
+### Wavelet matrix
 
 A **plain** wavelet matrix (`WaveletMatrix`) uses `WMCore` with plain bitvectors (`BitVector`).
+A **run-length encoded** wavelet matrix (`RLWM`) uses `WMCore` with run-length encoded bitvectors (`RLVector`).
 
 Serialization format for plain wavelet matrices:
 

--- a/SERIALIZATION.md
+++ b/SERIALIZATION.md
@@ -1,6 +1,6 @@
 # Serialization formats
 
-For version 0.4.0. Updated 2024-03-04.
+For version 0.4.0. Updated 2025-12-24.
 
 Changes since version 0.2.0 are mentioned in the relevant location.
 

--- a/SERIALIZATION.md
+++ b/SERIALIZATION.md
@@ -1,6 +1,6 @@
 # Serialization formats
 
-For version 0.4.0. Updated 2022-08-18.
+For version 0.4.0. Updated 2024-03-04.
 
 Changes since version 0.2.0 are mentioned in the relevant location.
 
@@ -173,15 +173,16 @@ This process **reorders** the items in the vector by sorting them according to t
 ### Wavelet matrix core
 
 The **core** of a wavelet matrix (`WMCore`) consists of the bitvectors that handle the reordering.
+The bitvectors can be of any type that implements `FullBitVec`.
 
 Serialization format for the wavelet matrix core:
 
 1. `width`: Width of the items as an element.
-2. `levels`: A `BitVector` for each level in `0..width`.
+2. `levels`: A bitvector for each level in `0..width`.
 
 ### Plain wavelet matrix
 
-A **plain** wavelet matrix (`WaveletMatrix`) uses the core directly for representing the vector.
+A **plain** wavelet matrix (`WaveletMatrix`) uses `WMCore` with plain bitvectors (`BitVector`).
 
 Serialization format for plain wavelet matrices:
 

--- a/src/bin/bv-benchmark/utils.rs
+++ b/src/bin/bv-benchmark/utils.rs
@@ -7,17 +7,16 @@ use simple_sds::serialize::Serialize;
 use simple_sds::internal;
 
 use rand::Rng;
-use rand::distributions::Bernoulli;
-use rand_distr::{Geometric, Distribution};
+use rand_distr::{Bernoulli, Geometric, Distribution};
 
 //-----------------------------------------------------------------------------
 
 pub fn random_vector(len: usize, density: f64) -> BitVector {
     let mut data = RawVector::with_capacity(len);
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     if density == 0.5 {
         while data.len() < len {
-            unsafe { data.push_int(rng.gen(), 64); }
+            unsafe { data.push_int(rng.random(), 64); }
         }
     }
     else {
@@ -41,10 +40,10 @@ pub fn random_vector(len: usize, density: f64) -> BitVector {
 
 pub fn random_vector_runs(len: usize, flip: f64) -> BitVector {
     let mut data = RawVector::with_capacity(len);
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let dist = Geometric::new(flip).unwrap();
 
-    let mut value: bool = rng.gen();
+    let mut value: bool = rng.random();
     let mut iter = dist.sample_iter(&mut rng);
     while data.len() < len {
         let run = cmp::min(1 + (iter.next().unwrap() as usize), len - data.len());

--- a/src/bin/wm-benchmark/main.rs
+++ b/src/bin/wm-benchmark/main.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::uninlined_format_args,
+    clippy::new_without_default
+)]
+
 use simple_sds::ops::{Vector, Access, VectorIndex};
 use simple_sds::serialize::Serialize;
 use simple_sds::wavelet_matrix::WaveletMatrix;
@@ -23,27 +28,27 @@ fn main() {
 
     println!("Generating {} random access queries over the vector", config.queries);
     let access_queries = internal::random_queries(config.queries, wm.len());
-    println!("");
+    println!();
 
     println!("Generating {} random rank queries over the vector", config.queries);
     let rank_queries = query_pairs(config.queries, wm.len(), wm.width());
-    println!("");
+    println!();
 
     println!("Generating {} random inverse select queries over the vector", config.queries);
     let inverse_select_queries = internal::random_queries(config.queries, wm.len());
-    println!("");
+    println!();
 
     println!("Generating {} random select queries over the vector", config.queries);
     let select_queries = query_pairs(config.queries, wm.len() >> wm.width(), wm.width());
-    println!("");
+    println!();
 
     println!("Generating {} random predecessor queries over the vector", config.queries);
     let predecessor_queries = query_pairs(config.queries, wm.len(), wm.width());
-    println!("");
+    println!();
 
     println!("Generating {} random successor queries over the vector", config.queries);
     let successor_queries = query_pairs(config.queries, wm.len(), wm.width());
-    println!("");
+    println!();
 
     independent_access(&wm, &access_queries, "WaveletMatrix");
     independent_rank(&wm, &rank_queries, "WaveletMatrix");
@@ -80,7 +85,7 @@ impl Config {
         let matches = match opts.parse(&args[1..]) {
             Ok(m) => m,
             Err(f) => {
-                eprintln!("{}", f.to_string());
+                eprintln!("{}", f);
                 process::exit(1);
             }
         };
@@ -105,7 +110,7 @@ impl Config {
                     config.len = 1 << n;
                 },
                 Err(f) => {
-                    eprintln!("--bit-len: {}", f.to_string());
+                    eprintln!("--bit-len: {}", f);
                     process::exit(1);
                 },
             }
@@ -120,7 +125,7 @@ impl Config {
                     config.width = n;
                 },
                 Err(f) => {
-                    eprintln!("--width: {}", f.to_string());
+                    eprintln!("--width: {}", f);
                     process::exit(1);
                 },
             }
@@ -135,7 +140,7 @@ impl Config {
                     config.queries = n;
                 },
                 Err(f) => {
-                    eprintln!("--queries: {}", f.to_string());
+                    eprintln!("--queries: {}", f);
                     process::exit(1);
                 },
             }

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -329,7 +329,7 @@ impl Transformation for Identity {
 
     #[inline]
     unsafe fn word_unchecked(parent: &BitVector, index: usize) -> u64 {
-        parent.data.word_unchecked(index)
+        unsafe { parent.data.word_unchecked(index) }
     }
 
     #[inline]
@@ -363,10 +363,12 @@ impl Transformation for Complement {
 
     unsafe fn word_unchecked(parent: &BitVector, index: usize) -> u64 {
         let (last_index, offset) = bits::split_offset(parent.len());
-        if index >= last_index {
-            (!parent.data.word_unchecked(index)) & bits::low_set_unchecked(offset)
-        } else {
-            !parent.data.word_unchecked(index)
+        unsafe {
+            if index >= last_index {
+                (!parent.data.word_unchecked(index)) & bits::low_set_unchecked(offset)
+            } else {
+                !parent.data.word_unchecked(index)
+            }
         }
     }
 

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -2,7 +2,7 @@
 
 use crate::bit_vector::rank_support::RankSupport;
 use crate::bit_vector::select_support::SelectSupport;
-use crate::ops::{BitVec, Rank, Select, SelectZero, PredSucc};
+use crate::ops::{BitVec, Rank, Select, SelectZero, PredSucc, FullBitVec};
 use crate::raw_vector::{RawVector, AccessRaw, PushRaw};
 use crate::serialize::Serialize;
 use crate::bits;
@@ -709,6 +709,8 @@ impl Serialize for BitVector {
 }
 
 //-----------------------------------------------------------------------------
+
+impl<'a> FullBitVec<'a> for BitVector {}
 
 impl AsRef<RawVector> for BitVector {
     #[inline]

--- a/src/bit_vector/select_support.rs
+++ b/src/bit_vector/select_support.rs
@@ -121,7 +121,7 @@ impl<T: Transformation> SelectSupport<T> {
         let mut iter = T::one_iter(parent);
         let mut value = iter.next();
 
-        while sample != None {
+        while sample.is_some() {
             let start = sample.unwrap();
             let next_sample = sample_iter.nth(Self::SUPERBLOCK_SIZE - 1);
             let limit = match next_sample {

--- a/src/bit_vector/tests.rs
+++ b/src/bit_vector/tests.rs
@@ -6,17 +6,17 @@ use crate::{internal, serialize};
 
 use std::cmp;
 
-use rand::distributions::{Bernoulli, Distribution};
+use rand_distr::{Bernoulli, Distribution};
 use rand::Rng;
 
 //-----------------------------------------------------------------------------
 
 fn random_raw_vector(len: usize, density: f64) -> RawVector {
     let mut data = RawVector::with_capacity(len);
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     if density == 0.5 {
         while data.len() < len {
-            unsafe { data.push_int(rng.gen(), cmp::min(len - data.len(), 64)); }
+            unsafe { data.push_int(rng.random(), cmp::min(len - data.len(), 64)); }
         }
     }
     else {
@@ -50,7 +50,7 @@ fn random_vector(len: usize, density: f64) -> BitVector {
 // The final bitvector may be complemented if necessary.
 fn non_uniform_vector(regions: &[(usize, f64)], complement: bool) -> BitVector {
     let mut data = RawVector::new();
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut total_ones: usize = 0;
     for (ones, density) in regions.iter() {
         let dist = Bernoulli::new(*density).unwrap();

--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -2,10 +2,10 @@
 
 use crate::ops::{Vector, Resize, Pack, Access, AccessIter, Push, Pop};
 use crate::raw_vector::{RawVector, RawVectorWriter, AccessRaw, PushRaw, PopRaw};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 use crate::raw_vector::RawVectorMapper;
 use crate::serialize::Serialize;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 use crate::serialize::{MemoryMap, MemoryMapped};
 use crate::bits;
 
@@ -584,7 +584,7 @@ impl Drop for IntVectorWriter {
 /// drop(mapper); drop(map);
 /// fs::remove_file(&filename).unwrap();
 /// ```
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 #[derive(PartialEq, Eq, Debug)]
 pub struct IntVectorMapper<'a> {
     len: usize,
@@ -592,7 +592,7 @@ pub struct IntVectorMapper<'a> {
     data: RawVectorMapper<'a>,
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> Vector for IntVectorMapper<'a> {
     type Item = u64;
 
@@ -612,7 +612,7 @@ impl<'a> Vector for IntVectorMapper<'a> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> Access<'a> for IntVectorMapper<'a> {
     type Iter = AccessIter<'a, Self>;
 
@@ -627,7 +627,7 @@ impl<'a> Access<'a> for IntVectorMapper<'a> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> MemoryMapped<'a> for IntVectorMapper<'a> {
     fn new(map: &'a MemoryMap, offset: usize) -> io::Result<Self> {
         if offset + 1 >= map.len() {
@@ -651,7 +651,7 @@ impl<'a> MemoryMapped<'a> for IntVectorMapper<'a> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> AsRef<RawVectorMapper<'a>> for IntVectorMapper<'a> {
     #[inline]
     fn as_ref(&self) -> &RawVectorMapper<'a> {

--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -656,8 +656,18 @@ macro_rules! from_extend_int_vector {
     ($t:ident, $w:expr) => {
         impl From<Vec<$t>> for IntVector {
             fn from(v: Vec<$t>) -> Self {
-                let mut result = IntVector::with_capacity(v.len(), $w).unwrap();
+                let mut result = IntVector::new($w).unwrap();
                 result.extend(v);
+                result
+            }
+        }
+
+        impl From<&[$t]> for IntVector {
+            fn from(v: &[$t]) -> Self {
+                let mut result = IntVector::with_capacity(v.len(), $w).unwrap();
+                for value in v.iter() {
+                    result.push(*value as <Self as Vector>::Item);
+                }
                 result
             }
         }

--- a/src/int_vector/tests.rs
+++ b/src/int_vector/tests.rs
@@ -143,6 +143,13 @@ fn from_vec() {
 }
 
 #[test]
+fn from_slice() {
+    let correct: Vec<u64> = vec![1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89];
+    let int_vec = IntVector::from(&correct[..]);
+    internal::check_vector(&int_vec, &correct, 64);
+}
+
+#[test]
 fn extend() {
     let first: Vec<u64> = vec![1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89];
     let second: Vec<u64> = vec![1, 2, 4, 8, 16, 32, 64, 128];

--- a/src/int_vector/tests.rs
+++ b/src/int_vector/tests.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 use crate::ops::{Vector, Resize, Pack, Access, Push, Pop};
-use crate::serialize::{Serialize, MappingMode};
+use crate::serialize::Serialize;
+#[cfg(feature = "libc")]
+use crate::serialize::MappingMode;
 use crate::{serialize, internal};
 
 use std::fs::OpenOptions;
@@ -9,6 +11,7 @@ use std::fs;
 
 //-----------------------------------------------------------------------------
 
+#[cfg(feature = "libc")]
 fn random_int_vector(n: usize, width: usize) -> IntVector {
     let values = internal::random_vector(n, width);
     let mut result = IntVector::new(width).unwrap();
@@ -295,6 +298,7 @@ fn large_writer() {
 
 //-----------------------------------------------------------------------------
 
+#[cfg(feature = "libc")]
 fn check_mapper(mapper: &IntVectorMapper, truth: &IntVector) {
     assert!(!mapper.is_mutable(), "Read-only mapper is mutable");
     assert_eq!(mapper.len(), truth.len(), "Invalid mapper length");
@@ -314,6 +318,7 @@ fn check_mapper(mapper: &IntVectorMapper, truth: &IntVector) {
     }
 }
 
+#[cfg(feature = "libc")]
 #[test]
 fn empty_mapper() {
     let filename = serialize::temp_file_name("empty-int-vector-mapper");
@@ -328,6 +333,7 @@ fn empty_mapper() {
     fs::remove_file(&filename).unwrap();
 }
 
+#[cfg(feature = "libc")]
 #[test]
 fn non_empty_mapper() {
     let filename = serialize::temp_file_name("non-empty-int-vector-mapper");
@@ -342,6 +348,7 @@ fn non_empty_mapper() {
     fs::remove_file(&filename).unwrap();
 }
 
+#[cfg(feature = "libc")]
 #[test]
 fn mapper_offset() {
     let filename = serialize::temp_file_name("int-vector-mapper-offset");
@@ -362,6 +369,7 @@ fn mapper_offset() {
     fs::remove_file(&filename).unwrap();
 }
 
+#[cfg(feature = "libc")]
 #[test]
 #[ignore]
 fn large_mapper() {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -95,7 +95,30 @@ pub fn random_integer_runs(n: usize, width: usize, p: f64) -> Vec<(u64, usize)> 
     for _ in 0..n {
         let value: u64 = rng.random::<u64>() & mask;
         let len = 1 + (dist.sample(&mut rng) as usize);
-        runs.push((value & bits::low_set(width), len));
+        runs.push((value, len));
+    }
+
+    runs
+}
+
+// Returns random runs of total length `len`, where lengths are `Geometric(p)`.
+// The values are in `0..(1 << width)`, and it is possible that the same value is repeated.
+// Note that `p` is the flip probability.
+pub fn random_integer_runs_with_len(len: usize, width: usize, p: f64) -> Vec<(u64, usize)> {
+    let mut runs: Vec<(u64, usize)> = Vec::new();
+    let mut rng = rand::rng();
+    let dist = Geometric::new(p).unwrap();
+
+    let mask = bits::low_set(width);
+    let mut total_len = 0;
+    while total_len < len {
+        let value: u64 = rng.random::<u64>() & mask;
+        let mut run_len = 1 + (dist.sample(&mut rng) as usize);
+        if total_len + run_len > len {
+            run_len = len - total_len;
+        }
+        runs.push((value, run_len));
+        total_len += run_len;
     }
 
     runs

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -14,9 +14,9 @@ use rand_distr::{Geometric, Distribution};
 // Returns a vector of `len` random `width`-bit integers.
 pub fn random_vector(len: usize, width: usize) -> Vec<u64> {
     let mut result: Vec<u64> = Vec::with_capacity(len);
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     for _ in 0..len {
-        let value: u64 = rng.gen();
+        let value: u64 = rng.random();
         result.push(value & bits::low_set(width));
     }
     result
@@ -25,9 +25,9 @@ pub fn random_vector(len: usize, width: usize) -> Vec<u64> {
 // Returns `n` random values in `0..universe`.
 pub fn random_queries(n: usize, universe: usize) -> Vec<usize>{
     let mut result: Vec<usize> = Vec::with_capacity(n);
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     for _ in 0..n {
-        let value: usize = rng.gen();
+        let value: usize = rng.random::<u64>() as usize;
         result.push(value % universe);
     }
     result
@@ -37,7 +37,7 @@ pub fn random_queries(n: usize, universe: usize) -> Vec<usize>{
 // The distances between positions are `Geometric(density)`.
 pub fn random_positions(n: usize, density: f64) -> (Vec<usize>, usize) {
     let mut positions: Vec<usize> = Vec::with_capacity(n);
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let dist = Geometric::new(density).unwrap();
     let mut universe = 0;
 
@@ -57,11 +57,11 @@ pub fn random_positions(n: usize, density: f64) -> (Vec<usize>, usize) {
 // Note that `p` is the flip probability.
 pub fn random_runs(n: usize, p: f64) -> (Vec<(usize, usize)>, usize) {
     let mut runs: Vec<(usize, usize)> = Vec::with_capacity(n);
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let dist = Geometric::new(p).unwrap();
 
-    let start_with_one: bool = rng.gen();
-    let end_with_zero: bool = rng.gen();
+    let start_with_one: bool = rng.random();
+    let end_with_zero: bool = rng.random();
     let mut universe = 0;
     let mut iter = dist.sample_iter(&mut rng);
     if start_with_one {
@@ -87,12 +87,12 @@ pub fn random_runs(n: usize, p: f64) -> (Vec<(usize, usize)>, usize) {
 // Note that `p` is the flip probability.
 pub fn random_integer_runs(n: usize, width: usize, p: f64) -> Vec<(u64, usize)> {
     let mut runs: Vec<(u64, usize)> = Vec::with_capacity(n);
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let dist = Geometric::new(p).unwrap();
 
     let mask = bits::low_set(width);
     for _ in 0..n {
-        let value: u64 = rng.gen::<u64>() & mask;
+        let value: u64 = rng.random::<u64>() & mask;
         let len = 1 + (dist.sample(&mut rng) as usize);
         runs.push((value & bits::low_set(width), len));
     }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -491,7 +491,7 @@ where
 {
     for value in 0..(1 << width) {
         let mut iter = v.value_iter(value);
-        assert_eq!(T::value_of(&iter), value, "Invalid value for value_iter({})", value);
+        assert_eq!(v.value_of(&iter), value, "Invalid value for value_iter({})", value);
         let mut rank = 0;
         let mut index = 0;
         while index < v.len() {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -156,7 +156,7 @@ pub fn report_results(queries: usize, total: usize, len: usize, duration: Durati
 //-----------------------------------------------------------------------------
 
 // Returns peak RSS size so far; Linux version.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "libc"))]
 pub fn peak_memory_usage() -> Result<usize, &'static str> {
     unsafe {
         let mut rusage: libc::rusage = std::mem::zeroed();
@@ -169,7 +169,7 @@ pub fn peak_memory_usage() -> Result<usize, &'static str> {
 }
 
 // Returns peak RSS size so far; macOS version.
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "libc"))]
 pub fn peak_memory_usage() -> Result<usize, &'static str> {
     unsafe {
         let mut rusage: libc::rusage = std::mem::zeroed();
@@ -182,7 +182,7 @@ pub fn peak_memory_usage() -> Result<usize, &'static str> {
 }
 
 // Returns peak RSS size so far; generic version.
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(all(any(target_os = "linux", target_os = "macos"), feature = "libc")))]
 pub fn peak_memory_usage() -> Result<usize, &'static str> {
     Err("No peak_memory_usage implementation for this OS")
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -82,6 +82,24 @@ pub fn random_runs(n: usize, p: f64) -> (Vec<(usize, usize)>, usize) {
     (runs, universe)
 }
 
+// Returns `n` random (value, length) runs, where lengths are `Geometric(p)`.
+// The values are in `0..(1 << width)`, and it is possible that the same value is repeated.
+// Note that `p` is the flip probability.
+pub fn random_integer_runs(n: usize, width: usize, p: f64) -> Vec<(u64, usize)> {
+    let mut runs: Vec<(u64, usize)> = Vec::with_capacity(n);
+    let mut rng = rand::thread_rng();
+    let dist = Geometric::new(p).unwrap();
+
+    let mask = bits::low_set(width);
+    for _ in 0..n {
+        let value: u64 = rng.gen::<u64>() & mask;
+        let len = 1 + (dist.sample(&mut rng) as usize);
+        runs.push((value & bits::low_set(width), len));
+    }
+
+    runs
+}
+
 //-----------------------------------------------------------------------------
 
 // Returns a human-readable representation of a size in bytes.

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -101,6 +101,20 @@ pub fn random_integer_runs(n: usize, width: usize, p: f64) -> Vec<(u64, usize)> 
     runs
 }
 
+pub fn maximal_runs(runs: Vec<(u64, usize)>) -> Vec<(u64, usize)> {
+    let mut maximal: Vec<(u64, usize)> = Vec::new();
+    for (value, length) in runs.into_iter() {
+        if let Some(last) = maximal.last_mut() {
+            if last.0 == value {
+                last.1 += length;
+                continue;
+            }
+        }
+        maximal.push((value, length));
+    }
+    maximal
+}
+
 pub fn runs_to_values(runs: &[(u64, usize)]) -> Vec<u64> {
     let mut values: Vec<u64> = Vec::new();
     for &(value, length) in runs.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod int_vector;
 pub mod ops;
 pub mod raw_vector;
 pub mod rl_vector;
+pub mod rlwm;
 pub mod serialize;
 pub mod sparse_vector;
 pub mod support;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! * This crate is designed for the x86_64 architecture with the BMI2 instruction set (Intel Haswell / AMD Excavator or later).
 //! Some operations may be slow without the POPCNT, LZCNT, TZCNT, and PDEP instructions.
 //! * 64-bit ARM is also supported.
-//! * Unix-like operating system is required for `mmap()`.
+//! * Unix-like operating system is required for `mmap()`, which is enabled with feature `libc`.
 //! * Things may not work if the system is not little-endian or if `usize` is not 64-bit.
 
 #![allow(clippy::uninlined_format_args)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 //! * Unix-like operating system is required for `mmap()`.
 //! * Things may not work if the system is not little-endian or if `usize` is not 64-bit.
 
+#![allow(clippy::uninlined_format_args)]
+
 pub mod bit_vector;
 pub mod bits;
 pub mod int_vector;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -977,6 +977,7 @@ pub trait Rank<'a>: BitVec<'a> {
     /// May panic from I/O errors.
     #[inline]
     fn rank_zero(&self, index: usize) -> usize {
+        let index = cmp::min(index, self.len());
         index - self.rank(index)
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1152,6 +1152,6 @@ pub trait PredSucc<'a>: BitVec<'a> {
 /// A marker trait indicating that the structure is a fully functional bitvector.
 ///
 /// This trait implies all other bitvector traits as well as [`Serialize`].
-pub trait FullBitVec<'a>: BitVec<'a> + Rank<'a> + Select<'a> + PredSucc<'a> + Serialize {}
+pub trait FullBitVec<'a>: BitVec<'a> + Rank<'a> + Select<'a> + SelectZero<'a> + PredSucc<'a> + Serialize {}
 
 //-----------------------------------------------------------------------------

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -502,7 +502,7 @@ pub trait Pop: Vector {
 ///         Self::ValueIter { parent: self, value, rank: 0, index: 0, }
 ///     }
 ///
-///     fn value_of(iter: &Self::ValueIter) -> <Self as Vector>::Item {
+///     fn value_of(&self, iter: &Self::ValueIter) -> <Self as Vector>::Item {
 ///         iter.value
 ///     }
 ///
@@ -538,7 +538,7 @@ pub trait Pop: Vector {
 /// // Iterator
 /// let a: Vec<(usize, usize)> = vec.value_iter('a').collect();
 /// assert_eq!(a, vec![(0, 0), (1, 4)]);
-/// assert_eq!(Example::value_of(&vec.value_iter('c')), 'c');
+/// assert_eq!(vec.value_of(&vec.value_iter('c')), 'c');
 ///
 /// // Select
 /// assert_eq!(vec.select(0, 'c'), Some(2));
@@ -610,7 +610,11 @@ pub trait VectorIndex<'a>: Access<'a> {
     fn value_iter(&'a self, value: <Self as Vector>::Item) -> Self::ValueIter;
 
     /// Returns the value of the items iterated over by the iterator.
-    fn value_of(iter: &Self::ValueIter) -> <Self as Vector>::Item;
+    ///
+    /// The iterator must belong to this vector.
+    /// The value is usually stored in the iterator.
+    /// This method provides a generic way to access it.
+    fn value_of(&self, iter: &Self::ValueIter) -> <Self as Vector>::Item;
 
     /// Returns the index of the vector that contains the occurrence of item `value` of rank `rank`.
     ///

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -16,6 +16,9 @@
 //! * [`Select`]: Select queries and iterators over set bits.
 //! * [`SelectZero`]: Select queries on the complement and iterators over unset bits.
 //! * [`PredSucc`]: Predecessor and successor queries.
+//! * [`FullBitVec`]: A fully functional bitvector with the above operations as well as [`Serialize`].
+
+use crate::serialize::Serialize;
 
 use std::iter::FusedIterator;
 use std::cmp;
@@ -1143,5 +1146,12 @@ pub trait PredSucc<'a>: BitVec<'a> {
     /// The iterator may also panic for the same reasons.
     fn successor(&'a self, value: usize) -> Self::OneIter;
 }
+
+//-----------------------------------------------------------------------------
+
+/// A marker trait indicating that the structure is a fully functional bitvector.
+///
+/// This trait implies all other bitvector traits as well as [`Serialize`].
+pub trait FullBitVec<'a>: BitVec<'a> + Rank<'a> + Select<'a> + PredSucc<'a> + Serialize {}
 
 //-----------------------------------------------------------------------------

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -208,7 +208,7 @@ pub trait Pack: Vector {
 /// See [`Vector`] for an example and [`AccessIter`] for a possible implementation of the iterator.
 pub trait Access<'a>: Vector {
     /// Iterator over the items in the vector.
-    type Iter: Iterator<Item = <Self as Vector>::Item> + ExactSizeIterator;
+    type Iter: Iterator<Item = <Self as Vector>::Item> + ExactSizeIterator + FusedIterator;
 
     /// Returns an item from the vector.
     ///

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -938,6 +938,8 @@ pub trait BitVec<'a> {
 
 //-----------------------------------------------------------------------------
 
+// TODO: Add inverse_select that returns (bv.rank(bv[i]), bv[i])
+// TODO: with a default implementation using get() and rank() / rank_zero()
 /// Rank queries on a bitvector.
 ///
 /// Some bitvector types do not build rank/select support structures by default.

--- a/src/ops/tests.rs
+++ b/src/ops/tests.rs
@@ -87,7 +87,7 @@ impl<'a> VectorIndex<'a> for NaiveVector {
         }
     }
 
-    fn value_of(iter: &Self::ValueIter) -> <Self as Vector>::Item {
+    fn value_of(&self, iter: &Self::ValueIter) -> <Self as Vector>::Item {
         iter.value
     }
 

--- a/src/raw_vector.rs
+++ b/src/raw_vector.rs
@@ -4,7 +4,7 @@ use crate::serialize::{MappedSlice, MemoryMap, MemoryMapped, Serialize};
 use crate::bits;
 
 use std::fs::{File, OpenOptions};
-use std::io::{Error, ErrorKind, Seek, SeekFrom};
+use std::io::{Error, ErrorKind, Seek};
 use std::path::{Path, PathBuf};
 use std::{cmp, io};
 
@@ -808,7 +808,7 @@ impl RawVectorWriter {
     // Seeks to the start of the file, appends its own header to `header`, and writes it into the file.
     fn write_header(&mut self, header: &mut Vec<u64>) -> io::Result<()> {
         if let Some(f) = self.file.as_mut() {
-            f.seek(SeekFrom::Start(0))?;
+            f.rewind()?;
             header.push(self.len as u64);
             header.push(bits::bits_to_words(self.len) as u64);
             header.serialize_body(f)?;

--- a/src/raw_vector.rs
+++ b/src/raw_vector.rs
@@ -534,7 +534,7 @@ impl AccessRaw for RawVector {
         if width == 0 {
             return 0;
         }
-        bits::read_int(&self.data, bit_offset, width)
+        unsafe { bits::read_int(&self.data, bit_offset, width) }
     }
 
     #[inline]
@@ -544,7 +544,7 @@ impl AccessRaw for RawVector {
 
     #[inline]
     unsafe fn word_unchecked(&self, index: usize) -> u64 {
-        *self.data.get_unchecked(index)
+        unsafe { *self.data.get_unchecked(index) }
     }
 
     #[inline]
@@ -564,7 +564,7 @@ impl AccessRaw for RawVector {
         if width == 0 {
             return;
         }
-        bits::write_int(&mut self.data, bit_offset, value, width);
+        unsafe { bits::write_int(&mut self.data, bit_offset, value, width); }
     }
 }
 
@@ -585,7 +585,7 @@ impl PushRaw for RawVector {
         if self.len + width > bits::words_to_bits(self.data.len()) {
             self.data.push(0);
         }
-        bits::write_int(&mut self.data, self.len, value, width);
+        unsafe { bits::write_int(&mut self.data, self.len, value, width); }
         self.len += width;
     }
 }
@@ -608,7 +608,7 @@ impl PopRaw for RawVector {
             if width == 0 {
                 return Some(0);
             }
-            let result = self.int(self.len - width, width);
+            let result = unsafe { self.int(self.len - width, width) };
             self.len -= width;
             self.data.resize(bits::bits_to_words(self.len()), 0); // Avoid using unnecessary words.
             self.set_unused_bits(false);
@@ -874,7 +874,8 @@ impl PushRaw for RawVectorWriter {
         if width == 0 {
             return;
         }
-        self.buf.push_int(value, width); self.len += width;
+        unsafe { self.buf.push_int(value, width); }
+        self.len += width;
         if self.buf.len() >= self.buf_len {
             self.flush(FlushMode::Safe).unwrap();
         }
@@ -967,7 +968,7 @@ impl<'a> AccessRaw for RawVectorMapper<'a> {
         if width == 0 {
             return 0;
         }
-        bits::read_int(&self.data, bit_offset, width)
+        unsafe { bits::read_int(&self.data, bit_offset, width) }
     }
 
     #[inline]
@@ -977,7 +978,7 @@ impl<'a> AccessRaw for RawVectorMapper<'a> {
 
     #[inline]
     unsafe fn word_unchecked(&self, index: usize) -> u64 {
-        *self.data.get_unchecked(index)
+        unsafe { *self.data.get_unchecked(index) }
     }
 
     #[inline]

--- a/src/raw_vector.rs
+++ b/src/raw_vector.rs
@@ -1,7 +1,7 @@
 //! The basic vector implementing the low-level functionality used by other vectors in the crate.
 
 use crate::serialize::Serialize;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 use crate::serialize::{MappedSlice, MemoryMap, MemoryMapped};
 use crate::bits;
 
@@ -924,14 +924,14 @@ impl Drop for RawVectorWriter {
 /// drop(mapper); drop(map);
 /// fs::remove_file(&filename);
 /// ```
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 #[derive(PartialEq, Eq, Debug)]
 pub struct RawVectorMapper<'a> {
     len: usize,
     data: MappedSlice<'a, u64>,
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> RawVectorMapper<'a> {
     /// Returns the length of the vector in bits.
     #[inline]
@@ -955,7 +955,7 @@ impl<'a> RawVectorMapper<'a> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> AccessRaw for RawVectorMapper<'a> {
     #[inline]
     fn bit(&self, bit_offset: usize) -> bool {
@@ -997,7 +997,7 @@ impl<'a> AccessRaw for RawVectorMapper<'a> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> MemoryMapped<'a> for RawVectorMapper<'a> {
     fn new(map: &'a MemoryMap, offset: usize) -> io::Result<Self> {
         if offset >= map.len() {
@@ -1020,7 +1020,7 @@ impl<'a> MemoryMapped<'a> for RawVectorMapper<'a> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> AsRef<MappedSlice<'a, u64>> for RawVectorMapper<'a> {
     #[inline]
     fn as_ref(&self) -> &MappedSlice<'a, u64> {

--- a/src/raw_vector/tests.rs
+++ b/src/raw_vector/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[cfg(feature = "libc")]
 use crate::serialize::MappingMode;
 use crate::serialize;
 
@@ -19,6 +20,7 @@ fn random_vector(n: usize, width: usize) -> Vec<u64> {
     result
 }
 
+#[cfg(feature = "libc")]
 fn random_raw_vector(n: usize, width: usize) -> RawVector {
     let values = random_vector(n, width);
     let mut result = RawVector::with_capacity(values.len() * width);
@@ -343,6 +345,7 @@ fn large_writer() {
 
 //-----------------------------------------------------------------------------
 
+#[cfg(feature = "libc")]
 fn check_mapper(mapper: &RawVectorMapper, truth: &RawVector, width: usize) {
     assert!(!mapper.is_mutable(), "Read-only mapper is mutable");
     assert_eq!(mapper.len(), truth.len(), "Invalid mapper length");
@@ -361,6 +364,7 @@ fn check_mapper(mapper: &RawVectorMapper, truth: &RawVector, width: usize) {
     }
 }
 
+#[cfg(feature = "libc")]
 #[test]
 fn empty_mapper() {
     let filename = serialize::temp_file_name("empty-raw-vector-mapper");
@@ -375,6 +379,7 @@ fn empty_mapper() {
     fs::remove_file(&filename).unwrap();
 }
 
+#[cfg(feature = "libc")]
 #[test]
 fn non_empty_mapper() {
     let filename = serialize::temp_file_name("non-empty-raw-vector-mapper");
@@ -390,6 +395,7 @@ fn non_empty_mapper() {
     fs::remove_file(&filename).unwrap();
 }
 
+#[cfg(feature = "libc")]
 #[test]
 fn mapper_offset() {
     let filename = serialize::temp_file_name("raw-vector-mapper-offset");
@@ -410,6 +416,7 @@ fn mapper_offset() {
     fs::remove_file(&filename).unwrap();
 }
 
+#[cfg(feature = "libc")]
 #[test]
 #[ignore]
 fn large_mapper() {

--- a/src/raw_vector/tests.rs
+++ b/src/raw_vector/tests.rs
@@ -11,9 +11,9 @@ use rand::Rng;
 
 fn random_vector(n: usize, width: usize) -> Vec<u64> {
     let mut result: Vec<u64> = Vec::new();
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     for _ in 0..n {
-        let value: u64 = rng.gen();
+        let value: u64 = rng.random();
         result.push(value & bits::low_set(width));
     }
     result
@@ -269,9 +269,9 @@ fn push_bits_to_writer() {
     let filename = serialize::temp_file_name("push-bits-to-raw-vector-writer");
 
     let mut correct: Vec<bool> = Vec::new();
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     for _ in 0..3523 {
-        correct.push(rng.gen());
+        correct.push(rng.random());
     }
 
     let mut header: Vec<u64> = Vec::new();

--- a/src/rl_vector.rs
+++ b/src/rl_vector.rs
@@ -19,7 +19,8 @@
 //! A [`SampleIndex`] is used for narrowing down the range of the binary search.
 
 use crate::int_vector::IntVector;
-use crate::ops::{Vector, Access, Push, Resize, BitVec, Rank, Select, SelectZero, PredSucc};
+use crate::ops::{Vector, Access, Push, Resize};
+use crate::ops::{BitVec, Rank, Select, SelectZero, PredSucc, FullBitVec};
 use crate::rl_vector::index::SampleIndex;
 use crate::serialize::Serialize;
 use crate::bits;
@@ -1190,5 +1191,9 @@ impl Serialize for RLVector {
         self.data.size_in_elements()
     }
 }
+
+//-----------------------------------------------------------------------------
+
+impl<'a> FullBitVec<'a> for RLVector {}
 
 //-----------------------------------------------------------------------------

--- a/src/rl_vector.rs
+++ b/src/rl_vector.rs
@@ -328,6 +328,7 @@ impl RLBuilder {
     /// Returns the length of the bitvector.
     ///
     /// This is the first position that can be set.
+    #[inline]
     pub fn len(&self) -> usize {
         self.len
     }
@@ -335,16 +336,19 @@ impl RLBuilder {
     /// Returns `true` if the bitvector is empty.
     ///
     /// Makes Clippy happy.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Returns the number of set bits in the bitvector.
+    #[inline]
     pub fn count_ones(&self) -> usize {
         self.ones
     }
 
     /// Returns the number of unset bits in the bitvector.
+    #[inline]
     pub fn count_zeros(&self) -> usize {
         self.len() - self.count_ones()
     }

--- a/src/rl_vector.rs
+++ b/src/rl_vector.rs
@@ -392,7 +392,7 @@ impl RLBuilder {
     ///
     /// Behavior is undefined if `index < self.len()`.
     pub unsafe fn set_bit_unchecked(&mut self, index: usize) {
-        self.set_run_unchecked(index, 1);
+        unsafe { self.set_run_unchecked(index, 1); }
     }
 
     /// Encodes a run of set bits of length `len` starting at position `start`.

--- a/src/rl_vector.rs
+++ b/src/rl_vector.rs
@@ -111,9 +111,9 @@ mod tests;
 /// // Operations returning remaining run lengths
 /// let rank_result = rv.rank_with_run(100);
 /// assert_eq!(rank_result, Some((27, true, 20)));
-/// let select_result = rv.select_with_run(40);
+/// let select_result = rv.select_run(40);
 /// assert_eq!(select_result, Some((113, 7)));
-/// let select_zero_result = rv.select_zero_with_run(50);
+/// let select_zero_result = rv.select_zero_run(50);
 /// assert_eq!(select_zero_result, Some((72, 23)));
 /// ```
 ///
@@ -1198,7 +1198,7 @@ impl RLVector {
     /// Returns the bit array index for set bit of the given rank, as well as the length of the right-maximal run containing it.
     ///
     /// Returns [`None`] if there is no such set bit.
-    pub fn select_with_run(&self, rank: usize) -> Option<(usize, usize)> {
+    pub fn select_run(&self, rank: usize) -> Option<(usize, usize)> {
         if rank >= self.count_ones() {
             return None;
         }
@@ -1217,7 +1217,7 @@ impl RLVector {
     /// Returns the bit array index for unset bit of the given rank, as well as the length of the right-maximal run containing it.
     ///
     /// Returns [`None`] if there is no such unset bit.
-    pub fn select_zero_with_run(&self, rank: usize) -> Option<(usize, usize)> {
+    pub fn select_zero_run(&self, rank: usize) -> Option<(usize, usize)> {
         if rank >= self.count_zeros() {
             return None;
         }

--- a/src/rl_vector.rs
+++ b/src/rl_vector.rs
@@ -1230,7 +1230,11 @@ impl RLVector {
                 return Some((index, run_len));
             }
         }
-        None
+
+        // We have a trailing run of unset bits.
+        let index = self.len() - (self.count_zeros() - rank);
+        let run_len = self.len() - index;
+        Some((index, run_len))
     }
 }
 

--- a/src/rl_vector/index.rs
+++ b/src/rl_vector/index.rs
@@ -144,23 +144,23 @@ mod tests {
         let mut last = 0;
         while last < universe {
             values.push(last);
-            last += 1 + rng.gen_range(0..density);
+            last += 1 + rng.random_range(0..density);
         }
         values
     }
 
     #[test]
     fn parameters() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut values: Vec<usize> = (1..10).collect();
         for _ in 0..100 {
-            values.push(rng.gen_range(1..10000));
+            values.push(rng.random_range(1..10000));
         }
 
         for v in values {
             let mut universe: Vec<usize> = vec![v, v + 1, v * SampleIndex::RATIO - 1, v * SampleIndex::RATIO, v * SampleIndex::RATIO + 1];
             for _ in 0..10 {
-                universe.push(v * rng.gen_range(1..10) + rng.gen_range(0..v));
+                universe.push(v * rng.random_range(1..10) + rng.random_range(0..v));
             }
             for u in universe {
                 check_parameters(v, u);
@@ -170,14 +170,14 @@ mod tests {
 
     #[test]
     fn sample_index() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         for _ in 0..10 {
-            let universe = rng.gen_range(10_000..100_000);
-            let density = rng.gen_range(2..1000);
+            let universe = rng.random_range(10_000..100_000);
+            let density = rng.random_range(2..1000);
             let values = generate_values(universe, density, &mut rng);
             let index = SampleIndex::new(values.iter().copied(), universe);
             for _ in 0..1000 {
-                let query = rng.gen_range(0..universe);
+                let query = rng.random_range(0..universe);
                 let range = index.range(query);
                 let start = values[range.start];
                 assert!(start <= query, "Range start values[{}] = {} is too large for query {} (universe size {}, density {})", range.start, start, query, universe, density);

--- a/src/rl_vector/tests.rs
+++ b/src/rl_vector/tests.rs
@@ -341,13 +341,13 @@ fn test_run_ops(rv: &RLVector) {
         let (rank, value, run_len) = result.unwrap();
         assert_eq!(value, rv.get(index), "rank_with_run returned incorrect value at index {} (len {})", index, rv.len());
         let (true_rank, rank_at_end, rank_past_end) = if value {
-            (rv.rank(index), rv.rank(index + run_len - 1), rv.rank(index + run_len))
+            (rv.rank(index), rv.rank(index + run_len), rv.rank(index + run_len + 1))
         } else {
-            (rv.rank_zero(index), rv.rank_zero(index + run_len - 1), rv.rank_zero(index + run_len))
+            (rv.rank_zero(index), rv.rank_zero(index + run_len), rv.rank_zero(index + run_len + 1))
         };
         assert_eq!(rank, true_rank, "rank_with_run returned incorrect rank {} at index {} (len {})", value, index, rv.len());
-        assert_eq!(rank + run_len - 1, rank_at_end, "rank_with_run returned incorrect {} run length at index {} (len {})", value, index, rv.len());
-        assert_eq!(rank + run_len, rank_past_end, "rank_with_run returned a non-maximal {} run length at index {} (len {})", value, index, rv.len());
+        assert_eq!(rank + run_len, rank_at_end, "rank_with_run did not return a {} run at index {} (len {})", value, index, rv.len());
+        assert_eq!(rank + run_len, rank_past_end, "rank_with_run returned a non-maximal {} run at index {} (len {})", value, index, rv.len());
     }
     let result = rv.rank_with_run(rv.len());
     assert!(result.is_none(), "rank_with_run returned a result for index past the end (len {})", rv.len());

--- a/src/rl_vector/tests.rs
+++ b/src/rl_vector/tests.rs
@@ -352,9 +352,35 @@ fn test_run_ops(rv: &RLVector) {
     let result = rv.rank_with_run(rv.len());
     assert!(result.is_none(), "rank_with_run returned a result for index past the end (len {})", rv.len());
 
-    // select_with_run
+    // select_run
+    for rank in 0..rv.count_ones() {
+        let result = rv.select_run(rank);
+        assert!(result.is_some(), "select_run returned None for rank {} (count_ones {})", rank, rv.count_ones());
+        let (index, run_len) = result.unwrap();
+        let true_index = rv.select(rank).unwrap();
+        assert_eq!(index, true_index, "select_run returned incorrect index for rank {} (count_ones {})", rank, rv.count_ones());
+        let run_end = rv.select(rank + run_len - 1);
+        assert_eq!(Some(index + run_len - 1), run_end, "select_run did not return a run for rank {} (count_ones {})", rank, rv.count_ones());
+        let after_run = rv.select(rank + run_len);
+        assert_ne!(Some(index + run_len), after_run, "select_run returned a non-maximal run for rank {} (count_ones {})", rank, rv.count_ones());
+    }
+    let result = rv.select_run(rv.count_ones());
+    assert!(result.is_none(), "select_run returned a result for rank past the end (count_ones {})", rv.count_ones());
 
-    // select_zero_with_run
+    // select_zero_run
+    for rank in 0..rv.count_zeros() {
+        let result = rv.select_zero_run(rank);
+        assert!(result.is_some(), "select_zero_run returned None for rank {} (count_zeros {})", rank, rv.count_zeros());
+        let (index, run_len) = result.unwrap();
+        let true_index = rv.select_zero(rank).unwrap();
+        assert_eq!(index, true_index, "select_zero_run returned incorrect index for rank {} (count_zeros {})", rank, rv.count_zeros());
+        let run_end = rv.select_zero(rank + run_len - 1);
+        assert_eq!(Some(index + run_len - 1), run_end, "select_zero_run did not return a run for rank {} (count_zeros {})", rank, rv.count_zeros());
+        let after_run = rv.select_zero(rank + run_len);
+        assert_ne!(Some(index + run_len), after_run, "select_zero_run returned a non-maximal run for rank {} (count_zeros {})", rank, rv.count_zeros());
+    }
+    let result = rv.select_zero_run(rv.count_zeros());
+    assert!(result.is_none(), "select_zero_run returned a result for rank past the end (count_zeros {})", rv.count_zeros());
 }
 
 #[test]

--- a/src/rl_vector/tests.rs
+++ b/src/rl_vector/tests.rs
@@ -332,3 +332,56 @@ fn large_pred_succ() {
 }
 
 //-----------------------------------------------------------------------------
+
+fn test_run_ops(rv: &RLVector) {
+    // rank_with_run
+    for index in 0..rv.len() {
+        let result = rv.rank_with_run(index);
+        assert!(result.is_some(), "rank_with_run returned None for index {} (len {})", index, rv.len());
+        let (rank, value, run_len) = result.unwrap();
+        assert_eq!(value, rv.get(index), "rank_with_run returned incorrect value at index {} (len {})", index, rv.len());
+        let (true_rank, rank_at_end, rank_past_end) = if value {
+            (rv.rank(index), rv.rank(index + run_len - 1), rv.rank(index + run_len))
+        } else {
+            (rv.rank_zero(index), rv.rank_zero(index + run_len - 1), rv.rank_zero(index + run_len))
+        };
+        assert_eq!(rank, true_rank, "rank_with_run returned incorrect rank {} at index {} (len {})", value, index, rv.len());
+        assert_eq!(rank + run_len - 1, rank_at_end, "rank_with_run returned incorrect {} run length at index {} (len {})", value, index, rv.len());
+        assert_eq!(rank + run_len, rank_past_end, "rank_with_run returned a non-maximal {} run length at index {} (len {})", value, index, rv.len());
+    }
+    let result = rv.rank_with_run(rv.len());
+    assert!(result.is_none(), "rank_with_run returned a result for index past the end (len {})", rv.len());
+
+    // select_with_run
+
+    // select_zero_with_run
+}
+
+#[test]
+fn empty_run_ops() {
+    let empty = zero_vector(0);
+    test_run_ops(&empty);
+}
+
+#[test]
+fn nonempty_run_ops() {
+    let rv = random_rl_vector(87, 0.025);
+    test_run_ops(&rv);
+}
+
+#[test]
+fn uniform_run_ops() {
+    let zeros = zero_vector(1903);
+    let ones = one_vector(1754);
+    test_run_ops(&zeros);
+    test_run_ops(&ones);
+}
+
+#[test]
+#[ignore]
+fn large_run_ops() {
+    let rv = random_rl_vector(20567, 0.03);
+    test_run_ops(&rv);
+}
+
+//-----------------------------------------------------------------------------

--- a/src/rlwm.rs
+++ b/src/rlwm.rs
@@ -177,7 +177,7 @@ impl<'a> VectorIndex<'a> for RLWM<'a> {
 }
 
 impl <'a> RLWM<'a> {
-    // FIXME: test, examples
+    // FIXME: examples
     /// Returns the right-maximal run of values starting at the given index.
     ///
     /// The returned tuple is (value, length).
@@ -191,7 +191,7 @@ impl <'a> RLWM<'a> {
         (result.1, result.2)
     }
 
-    // FIXME: test, examples
+    // FIXME: examples
     /// Returns the right-maximal run of the vector that starts with occurrence of item `value` of rank `rank`.
     ///
     /// The returned tuple is (starting index, run length).
@@ -237,7 +237,7 @@ impl<'a> Serialize for RLWM<'a> {
 
 //-----------------------------------------------------------------------------
 
-// FIXME: tests, examples
+// FIXME: examples
 /// A read-only iterator over the items in [`RLWM`].
 ///
 /// This is a more efficient override of the default iterator provided by [`Access`].
@@ -271,13 +271,14 @@ impl<'a> AccessIter<'a> {
     }
 
     // TODO: separate RunIter?
-    /// Returns the right-maximal run starting at the position [`Self::next`] would return next.
+    /// Returns the run starting at the position [`Self::next`] would return next.
     ///
     /// The returned tuple is (starting index, value, run length).
     /// Returns [`None`] if the iterator is exhausted.
     ///
     /// Advances the iterator to the end of the run.
-    /// The run may not be right-maximal, if [`DoubleEndedIterator::next_back`] has been used.
+    /// By default, the returned runs are maximal.
+    /// Using [`Iterator::next`] and [`DoubleEndedIterator::next_back`] may break maximality by consuming individual items.
     pub fn next_run(&mut self) -> Option<(usize, <RLWM<'a> as Vector>::Item, usize)> {
         self.ensure_next_run()?;
         let run_len = cmp::min(self.run_len, self.limit - self.index);
@@ -321,7 +322,7 @@ impl<'a> FusedIterator for AccessIter<'a> {}
 
 //-----------------------------------------------------------------------------
 
-// FIXME: example, tests
+// FIXME: example
 /// A read-only iterator over the occurrences of a specific value in [`RLWM`].
 ///
 /// The type of `Item` is [`(usize, usize)`] representing a pair (rank, index).
@@ -360,11 +361,14 @@ impl<'a> ValueIter<'a> {
     }
 
     // TODO: separate ValueRunIter?
-    /// Returns the right-maximal run starting at the position [`Self::next`] would return next.
+    /// Returns the run starting at the position [`Self::next`] would return next.
     ///
     /// The returned tuple is (rank, starting index, run length).
-    /// Advances the iterator to the end of the run.
     /// Returns [`None`] if the iterator is exhausted.
+    ///
+    /// Advances the iterator to the end of the run.
+    /// By default, the returned runs are maximal.
+    /// Using [`Iterator::next`] may break left-maximality by consuming individual items.
     pub fn next_run(&mut self) -> Option<(usize, usize, usize)> {
         self.ensure_next_run()?;
         let result = Some((self.rank, self.index, self.run_len));
@@ -392,7 +396,7 @@ impl<'a> FusedIterator for ValueIter<'a> {}
 
 //-----------------------------------------------------------------------------
 
-// FIXME example, tests
+// FIXME example
 /// [`RLWM`] iterator that consumes the vector.
 ///
 /// The type of `Item` is [`u64`].

--- a/src/rlwm.rs
+++ b/src/rlwm.rs
@@ -3,8 +3,15 @@
 // FIXME document
 
 use crate::int_vector::IntVector;
+use crate::ops::{Vector, Access, AccessIter, VectorIndex};
 use crate::rl_vector::RLVector;
+use crate::serialize::Serialize;
 use crate::wavelet_matrix::wm_core::WMCore;
+use crate::wavelet_matrix::wm_core;
+
+use std::io::{Error, ErrorKind};
+use std::iter::FusedIterator;
+use std::io;
 
 // FIXME tests
 
@@ -19,13 +26,151 @@ pub struct RLWM<'a> {
     first: IntVector,
 }
 
-// FIXME construction from runs of (value, length)
+// FIXME: special run-based operations such as select_run for iterators
+impl<'a> RLWM<'a> {
+    // Returns the starting offset of the value after reordering.
+    fn start(&self, value: <Self as Vector>::Item) -> usize {
+        self.first.get(value as usize) as usize
+    }
 
-// FIXME special run-based operations?
+    // Computes `first` from an iterator.
+    fn start_offsets<Iter: Iterator<Item = (u64, usize)>>(iter: Iter, len: usize, max_value: u64) -> IntVector {
+        // Count the number of occurrences of each value.
+        let mut counts: Vec<(u64, usize)> = Vec::with_capacity((max_value + 1) as usize);
+        for i in 0..=max_value {
+            counts.push((i, 0));
+        }
+        for (value, len) in iter {
+            counts[value as usize].1 += len;
+        }
+        wm_core::counts_to_first(counts, len)
+    }
+}
+
+impl<'a> From<Vec<(u64, usize)>> for RLWM<'a> {
+    fn from(runs: Vec<(u64, usize)>) -> Self {
+        let mut len = 0;
+        let mut max_value = 0;
+        for (value, length) in runs.iter() {
+            len += *length;
+            if *value > max_value {
+                max_value = *value;
+            }
+        }
+        let first = Self::start_offsets(runs.iter().copied(), len, max_value);
+        let data = WMCore::from(runs);
+        RLWM { len, data, first }
+    }
+}
 
 //-----------------------------------------------------------------------------
 
-// FIXME Vector, Access, VectorIndex, Serialize
+impl<'a> Vector for RLWM<'a> {
+    type Item = u64;
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    fn width(&self) -> usize {
+        self.data.width()
+    }
+
+    #[inline]
+    fn max_len(&self) -> usize {
+        usize::MAX
+    }
+}
+
+impl<'a> Access<'a> for RLWM<'a> {
+    type Iter = AccessIter<'a, Self>;
+
+    fn get(&self, index: usize) -> <Self as Vector>::Item {
+        self.inverse_select(index).unwrap().1
+    }
+
+    fn iter(&'a self) -> Self::Iter {
+        Self::Iter::new(self)
+    }
+}
+
+impl<'a> VectorIndex<'a> for RLWM<'a> {
+    type ValueIter = ValueIter<'a>;
+
+    fn contains(&self, value: <Self as Vector>::Item) -> bool {
+        (value as usize) < self.first.len() && self.start(value) < self.len()
+    }
+
+    fn rank(&self, index: usize, value: <Self as Vector>::Item) -> usize {
+        if !self.contains(value) {
+            return 0;
+        }
+        self.data.map_down_with(index, value) - self.start(value)
+    }
+
+    fn inverse_select(&self, index: usize) -> Option<(usize, <Self as Vector>::Item)> {
+        self.data.map_down(index).map(|(index, value)| (index - self.start(value), value))
+    }
+
+    fn value_iter(&'a self, value: <Self as Vector>::Item) -> Self::ValueIter {
+        Self::ValueIter {
+            parent: self,
+            value,
+            rank: 0,
+        }
+    }
+
+    fn value_of(iter: &Self::ValueIter) -> <Self as Vector>::Item {
+        iter.value
+    }
+
+    fn select(&self, rank: usize, value: <Self as Vector>::Item) -> Option<usize> {
+        if !self.contains(value) {
+            return None;
+        }
+        self.data.map_up_with(self.start(value) + rank, value)
+    }
+
+    fn select_iter(&'a self, rank: usize, value: <Self as Vector>::Item) -> Self::ValueIter {
+        Self::ValueIter {
+            parent: self,
+            value,
+            rank,
+        }
+    }
+}
+
+impl<'a> Serialize for RLWM<'a> {
+    fn serialize_header<T: io::Write>(&self, writer: &mut T) -> io::Result<()> {
+        self.len.serialize(writer)
+    }
+
+    fn serialize_body<T: io::Write>(&self, writer: &mut T) -> io::Result<()> {
+        self.data.serialize(writer)?;
+        self.first.serialize(writer)?;
+        Ok(())
+    }
+
+    fn load<T: io::Read>(reader: &mut T) -> io::Result<Self> {
+        let len = usize::load(reader)?;
+        let data = WMCore::load(reader)?;
+        if data.len() != len {
+            return Err(Error::new(ErrorKind::InvalidData, "Core length does not match wavelet matrix length"));
+        }
+
+        let first = IntVector::load(reader)?;
+        Ok(RLWM { len, data, first, })
+    }
+
+    fn size_in_elements(&self) -> usize {
+        let mut result = self.len.size_in_elements();
+        result += self.data.size_in_elements();
+        result += self.first.size_in_elements();
+        result
+    }
+}
 
 //-----------------------------------------------------------------------------
 
@@ -33,14 +178,41 @@ pub struct RLWM<'a> {
 
 //-----------------------------------------------------------------------------
 
-// FIXME ValueIter
+// FIXME Optimized ValueIter
+#[derive(Clone, Debug)]
+pub struct ValueIter<'a> {
+    parent: &'a RLWM<'a>,
+    value: <RLWM<'a> as Vector>::Item,
+    // The first rank we have not seen.
+    rank: usize,
+}
+
+impl<'a> Iterator for ValueIter<'a> {
+    type Item = (usize, usize);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.rank >= self.parent.len() {
+            return None;
+        }
+        if let Some(index) = self.parent.select(self.rank, self.value) {
+            let result = Some((self.rank, index));
+            self.rank += 1;
+            result
+        } else {
+            self.rank = self.parent.len();
+            None
+        }
+    }
+}
+
+impl<'a> FusedIterator for ValueIter<'a> {}
 
 //-----------------------------------------------------------------------------
 
-// FIXME RunIter
+// FIXME RunIter?
 
 //-----------------------------------------------------------------------------
 
-// FIXME ValueIter
+// FIXME IntoIter
 
 //-----------------------------------------------------------------------------

--- a/src/rlwm.rs
+++ b/src/rlwm.rs
@@ -1,0 +1,46 @@
+//! An immutable run-length encoded integer vector supporting rank/select-type queries.
+
+// FIXME document
+
+use crate::int_vector::IntVector;
+use crate::rl_vector::RLVector;
+use crate::wavelet_matrix::wm_core::WMCore;
+
+// FIXME tests
+
+//-----------------------------------------------------------------------------
+
+// FIXME document, example
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RLWM<'a> {
+    len: usize,
+    data: WMCore<'a, RLVector>,
+    // Starting offset of each value after reordering by the wavelet matrix, or `len` if the value does not exist.
+    first: IntVector,
+}
+
+// FIXME construction from runs of (value, length)
+
+// FIXME special run-based operations?
+
+//-----------------------------------------------------------------------------
+
+// FIXME Vector, Access, VectorIndex, Serialize
+
+//-----------------------------------------------------------------------------
+
+// FIXME AccessIter to replace the default 
+
+//-----------------------------------------------------------------------------
+
+// FIXME ValueIter
+
+//-----------------------------------------------------------------------------
+
+// FIXME RunIter
+
+//-----------------------------------------------------------------------------
+
+// FIXME ValueIter
+
+//-----------------------------------------------------------------------------

--- a/src/rlwm/tests.rs
+++ b/src/rlwm/tests.rs
@@ -99,6 +99,152 @@ fn large_rlwm_index() {
 
 //-----------------------------------------------------------------------------
 
-// FIXME: Functionality specific to RLWM
+fn consume_first_last(iter: &AccessIter<'_>, true_index: usize, true_value: u64, true_run_len: usize, len: usize) {
+    let mut iter = iter.clone();
+    let mut copy = iter.clone();
+    let _ = iter.next(); // consume first
+    let _ = iter.next_back(); // consume last
+    let run = iter.next_run();
+    let _ = copy.next_run(); // consume run
+    let _ = copy.next_back(); // consume last
+    let next = copy.next_run();
+
+    if true_index + true_run_len == len {
+        // We are at the last run.
+        if true_run_len <= 2 {
+            assert!(run.is_none(), "Iterator not exhausted after consuming the ends of a short last run");
+        } else {
+            let (index, value, run_len) = run.unwrap();
+            assert_eq!(index, true_index + 1, "Wrong iterator run index after consuming the ends of a short last run");
+            assert_eq!(value, true_value, "Wrong iterator run value after consuming the ends of a short last run");
+            assert_eq!(run_len, true_run_len - 2, "Wrong iterator run length after consuming the ends of a short last run");
+        }
+    } else if true_run_len == 1 {
+        // We expect to get the next run.
+        if true_index + true_run_len + 1 == len {
+            // And it is the final run consisting of a single item.
+            assert!(run.is_none(), "Iterator not exhausted after consuming two final single-item runs");
+        } else {
+            assert_eq!(run, next, "Iterator did not return the next run after consuming the only item at index {}", true_index);
+        }
+    } else {
+        // We have consumed the first item from the current run.
+        assert!(run.is_some(), "Iterator exhausted after consuming the first item at index {}", true_index);
+        let (index, value, run_len) = run.unwrap();
+        assert_eq!(index, true_index + 1, "Wrong iterator run index after consuming the first item at index {}", true_index);
+        assert_eq!(value, true_value, "Wrong iterator run value after consuming the first item at index {}", true_index);
+        assert_eq!(run_len, true_run_len - 1, "Wrong iterator run length after consuming the first item at index {}", true_index);
+    }
+}
+
+fn consume_first(iter: &ValueIter<'_>, true_rank: usize, true_index: usize, true_value: usize, true_run_len: usize) {
+    let mut iter = iter.clone();
+    let mut copy = iter.clone();
+    let _ = iter.next(); // consume first
+    let run = iter.next_run();
+    let _ = copy.next_run(); // consume run
+    let next = copy.next_run();
+
+    if true_run_len == 1 {
+        assert_eq!(run, next, "Value iterator did not return the next run after consuming the only item of a run for value {}", true_value);
+    } else {
+        let (rank, index, run_len) = run.unwrap();
+        assert_eq!(rank, true_rank + 1, "Wrong value iterator run rank after consuming the first item of a run for value {}", true_value);
+        assert_eq!(index, true_index + 1, "Wrong value iterator run index after consuming the first item of a run for value {}", true_value);
+        assert_eq!(run_len, true_run_len - 1, "Wrong value iterator run length after consuming the first item of a run for value {}", true_value);
+    }
+}
+
+// value_iter by consuming first
+fn check_runs(rlwm: &RLWM, runs: &[(u64, usize)], width: usize) {
+    let mut iter = rlwm.iter();
+    let mut value_iters = Vec::with_capacity(1 << width);
+    for value in 0..(1 << width) {
+        value_iters.push(rlwm.value_iter(value));
+    }
+    let mut value_ranks = vec![0; 1 << width];
+
+    let mut true_index = 0;
+    for &(true_value, true_run_len) in runs.iter() {
+        // get_run at each index
+        for offset in 0..true_run_len {
+            let (value, run_len) = rlwm.get_run(true_index + offset);
+            assert_eq!(value, true_value, "Wrong get_run value at index {}", true_index + offset);
+            assert_eq!(run_len, true_run_len - offset, "Wrong get_run run_len at index {}", true_index + offset);
+        }
+
+        // next_run from AccessIter
+        consume_first_last(&iter, true_index, true_value, true_run_len, rlwm.len());
+        let run = iter.next_run();
+        assert!(run.is_some(), "Iterator exhausted too early at index {}", true_index);
+        let (index, value, run_len) = run.unwrap();
+        assert_eq!(index, true_index, "Wrong iterator run index at index {}", true_index);
+        assert_eq!(value, true_value, "Wrong iterator run value at index {}", true_index);
+        assert_eq!(run_len, true_run_len, "Wrong iterator run length at index {}", true_index);
+
+        // next_run from ValueIter
+        let val = true_value as usize;
+        consume_first(&value_iters[val], value_ranks[val], true_index, val, true_run_len);
+        let run = value_iters[val].next_run();
+        assert!(run.is_some(), "Value iterator exhausted too early for value {} at index {}", true_value, true_index);
+        let (rank, index, run_len) = run.unwrap();
+        assert_eq!(rank, value_ranks[val], "Wrong value iterator run rank for value {} at index {}", true_value, true_index);
+        assert_eq!(index, true_index, "Wrong value iterator run index for value {} at index {}", true_value, true_index);
+        assert_eq!(run_len, true_run_len, "Wrong value iterator run length for value {} at index {}", true_value, true_index);
+
+        // select_run for each rank within the run
+        for offset in 0..true_run_len {
+            let rank = value_ranks[val] + offset;
+            let run = rlwm.select_run(rank, true_value);
+            assert!(run.is_some(), "select_run returned None for value {}, rank {}", true_value, rank);
+            let (index, run_len) = run.unwrap();
+            assert_eq!(index, true_index + offset, "Wrong select_run index for value {}, rank {}", true_value, rank);
+            assert_eq!(run_len, true_run_len - offset, "Wrong select_run run length for value {}, rank {}", true_value, rank);
+        }
+
+        true_index += true_run_len;
+        value_ranks[val] += true_run_len;
+    }
+
+    // Check that there are no extra runs or items.
+    // get_run will panic if out of bounds, so no need to check that.
+    let mut iter_copy = iter.clone();
+    assert!(iter.next_run().is_none(), "Iterator has extra runs after end");
+    assert!(iter_copy.next().is_none(), "Iterator has extra items after end");
+    for value in 0..(1 << width) {
+        let val = value as usize;
+        let mut iter_copy = value_iters[val].clone();
+        assert!(value_iters[val].next_run().is_none(), "Value iterator has extra runs after end for value {}", value);
+        assert!(iter_copy.next().is_none(), "Value iterator has extra items after end for value {}", value);
+        assert!(rlwm.select_run(value_ranks[val], value).is_none(), "select_run has extra runs after end for value {}", value);
+    }
+}
+
+#[test]
+fn empty_rlwm_runs() {
+    let width = 1;
+    let runs = Vec::new();
+    let rlwm = RLWM::from(runs.clone());
+    check_runs(&rlwm, &runs, width);
+}
+
+#[test]
+fn rlwm_runs() {
+    let width = 7;
+    let runs = internal::random_integer_runs(128, width, 0.05);
+    let rlwm = RLWM::from(runs.clone());
+    let runs = internal::maximal_runs(runs);
+    check_runs(&rlwm, &runs, width);
+}
+
+#[test]
+#[ignore]
+fn large_rlwm_runs() {
+    let width = 10;
+    let runs = internal::random_integer_runs(4095, width, 0.03);
+    let rlwm = RLWM::from(runs.clone());
+    let runs = internal::maximal_runs(runs);
+    check_runs(&rlwm, &runs, width);
+}
 
 //-----------------------------------------------------------------------------

--- a/src/rlwm/tests.rs
+++ b/src/rlwm/tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+use crate::{serialize, internal};
+
+//-----------------------------------------------------------------------------
+
+// From + check_vector
+
+#[test]
+fn empty_rlwm() {
+    let runs = Vec::new();
+    let truth = internal::runs_to_values(&runs);
+    let rlwm = RLWM::from(runs);
+    internal::check_vector(&rlwm, &truth, 1);
+
+}
+
+#[test]
+fn rlwm_from_runs() {
+    let width = 5;
+    let runs = internal::random_integer_runs(51, width, 0.03);
+    let truth = internal::runs_to_values(&runs);
+    let rlwm = RLWM::from(runs);
+    internal::check_vector(&rlwm, &truth, width);
+}
+
+#[test]
+#[ignore]
+fn large_rlwm() {
+    let width = 10;
+    let runs = internal::random_integer_runs(13842, width, 0.032);
+    let truth = internal::runs_to_values(&runs);
+    let rlwm = RLWM::from(runs);
+    internal::check_vector(&rlwm, &truth, width);
+}
+
+//-----------------------------------------------------------------------------
+
+// Serialize
+
+#[test]
+fn serialize_empty_rlwm() {
+    let runs = Vec::new();
+    let rlwm = RLWM::from(runs);
+    serialize::test(&rlwm, "rl-wavelet-matrix", None, true);
+}
+
+#[test]
+fn serialize_rlwm() {
+    let runs = internal::random_integer_runs(42, 7, 0.08);
+    let rlwm = RLWM::from(runs);
+    serialize::test(&rlwm, "rl-wavelet-matrix", None, true);
+}
+
+#[test]
+#[ignore]
+fn serialize_large_rlwm() {
+    let runs = internal::random_integer_runs(9836, 11, 0.025);
+    let rlwm = RLWM::from(runs);
+    serialize::test(&rlwm, "rl-wavelet-matrix", None, true);
+}
+
+//-----------------------------------------------------------------------------
+
+// VectorIndex
+
+#[test]
+fn empty_rlwm_index() {
+    let width = 1;
+    let runs = Vec::new();
+    let rlwm = RLWM::from(runs);
+    internal::check_vector_index(&rlwm, width);
+}
+
+#[test]
+fn rlwm_index() {
+    let width = 4;
+    let runs = internal::random_integer_runs(49, width, 0.04);
+    let rlwm = RLWM::from(runs);
+    internal::check_vector_index(&rlwm, width);
+}
+
+#[test]
+fn rlwm_index_missing_values() {
+    let width = 9;
+    let runs = internal::random_integer_runs(38, width, 0.07);
+    let rlwm = RLWM::from(runs);
+    internal::check_vector_index(&rlwm, width);
+}
+
+#[test]
+#[ignore]
+fn large_rlwm_index() {
+    let width = 6;
+    let runs = internal::random_integer_runs(1011, width, 0.04);
+    let rlwm = RLWM::from(runs);
+    internal::check_vector_index(&rlwm, width);
+}
+
+//-----------------------------------------------------------------------------
+
+// FIXME: Functionality specific to RLWM
+
+//-----------------------------------------------------------------------------

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -472,7 +472,7 @@ impl MemoryMap {
     ///
     /// Behavior is undefined if the file was opened with mode `MappingMode::ReadOnly`.
     pub unsafe fn as_mut_slice(&mut self) -> &mut [u64] {
-        slice::from_raw_parts_mut(self.ptr, self.len)
+        unsafe { slice::from_raw_parts_mut(self.ptr, self.len) }
     }
 
     /// Returns the length of the memory-mapped file.

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -54,17 +54,17 @@ use crate::bits;
 
 use std::fmt::Debug;
 use std::fs::OpenOptions;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 use std::fs::File;
 use std::io::{Error, ErrorKind, Read, Write};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 use std::ops::{Deref, Index};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{env, fs, io, mem, process, slice, str};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 use std::{marker, ptr};
 
 #[cfg(test)]
@@ -354,7 +354,7 @@ impl<V: Serialize> Serialize for Option<V> {
 //-----------------------------------------------------------------------------
 
 /// Modes of memory mapping a file.
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum MappingMode {
     /// The file is read-only.
@@ -393,7 +393,7 @@ pub enum MappingMode {
 /// drop(map);
 /// fs::remove_file(&filename).unwrap();
 /// ```
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 #[derive(Debug)]
 pub struct MemoryMap {
     _file: File, // The compiler might otherwise get overzealous and complain that we don't touch the file.
@@ -404,7 +404,7 @@ pub struct MemoryMap {
 }
 
 // TODO: implement madvise()?
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl MemoryMap {
     /// Returns a memory map for the specified file in the given mode.
     ///
@@ -488,14 +488,14 @@ impl MemoryMap {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl AsRef<[u64]> for MemoryMap {
     fn as_ref(&self) -> &[u64] {
         unsafe { slice::from_raw_parts(self.ptr, self.len) }
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl Drop for MemoryMap {
     fn drop(&mut self) {
         unsafe {
@@ -567,7 +567,7 @@ impl Drop for MemoryMap {
 ///
 /// fs::remove_file(&filename).unwrap();
 /// ```
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 pub trait MemoryMapped<'a>: Sized {
     /// Returns an immutable memory-mapped structure corresponding to an interval in the file.
     ///
@@ -616,14 +616,14 @@ pub trait MemoryMapped<'a>: Sized {
 ///
 /// fs::remove_file(&filename).unwrap();
 /// ```
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 #[derive(PartialEq, Eq, Debug)]
 pub struct MappedSlice<'a, T: Serializable> {
     data: &'a [T],
     offset: usize,
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a, T: Serializable> MappedSlice<'a, T> {
     /// Returns the length of the slice.
     pub fn len(&self) -> usize {
@@ -636,14 +636,14 @@ impl<'a, T: Serializable> MappedSlice<'a, T> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a, T: Serializable> AsRef<[T]> for MappedSlice<'a, T> {
     fn as_ref(&self) -> &[T] {
         self.data
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a, T: Serializable> Deref for MappedSlice<'a, T> {
     type Target = [T];
 
@@ -652,7 +652,7 @@ impl<'a, T: Serializable> Deref for MappedSlice<'a, T> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a, T: Serializable> Index<usize> for MappedSlice<'a, T> {
     type Output = T;
 
@@ -661,7 +661,7 @@ impl<'a, T: Serializable> Index<usize> for MappedSlice<'a, T> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a, T: Serializable> MemoryMapped<'a> for MappedSlice<'a, T> {
     fn new(map: &'a MemoryMap, offset: usize) -> io::Result<Self> {
         if offset >= map.len() {
@@ -715,14 +715,14 @@ impl<'a, T: Serializable> MemoryMapped<'a> for MappedSlice<'a, T> {
 ///
 /// fs::remove_file(&filename).unwrap();
 /// ```
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 #[derive(PartialEq, Eq, Debug)]
 pub struct MappedBytes<'a> {
     data: &'a [u8],
     offset: usize,
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> MappedBytes<'a> {
     /// Returns the length of the slice.
     pub fn len(&self) -> usize {
@@ -735,14 +735,14 @@ impl<'a> MappedBytes<'a> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> AsRef<[u8]> for MappedBytes<'a> {
     fn as_ref(&self) -> &[u8] {
         self.data
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> Deref for MappedBytes<'a> {
     type Target = [u8];
 
@@ -751,7 +751,7 @@ impl<'a> Deref for MappedBytes<'a> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> Index<usize> for MappedBytes<'a> {
     type Output = u8;
 
@@ -760,7 +760,7 @@ impl<'a> Index<usize> for MappedBytes<'a> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> MemoryMapped<'a> for MappedBytes<'a> {
     fn new(map: &'a MemoryMap, offset: usize) -> io::Result<Self> {
         if offset >= map.len() {
@@ -812,14 +812,14 @@ impl<'a> MemoryMapped<'a> for MappedBytes<'a> {
 ///
 /// fs::remove_file(&filename).unwrap();
 /// ```
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 #[derive(PartialEq, Eq, Debug)]
 pub struct MappedStr<'a> {
     data: &'a str,
     offset: usize,
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> MappedStr<'a> {
     /// Returns the length of the slice in bytes.
     pub fn len(&self) -> usize {
@@ -832,14 +832,14 @@ impl<'a> MappedStr<'a> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> AsRef<str> for MappedStr<'a> {
     fn as_ref(&self) -> &str {
         self.data
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> Deref for MappedStr<'a> {
     type Target = str;
 
@@ -847,7 +847,7 @@ impl<'a> Deref for MappedStr<'a> {
         self.data
     }
 }
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a> MemoryMapped<'a> for MappedStr<'a> {
     fn new(map: &'a MemoryMap, offset: usize) -> io::Result<Self> {
         if offset >= map.len() {
@@ -899,7 +899,7 @@ impl<'a> MemoryMapped<'a> for MappedStr<'a> {
 ///
 /// fs::remove_file(&filename).unwrap();
 /// ```
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 #[derive(PartialEq, Eq, Debug)]
 pub struct MappedOption<'a, T: MemoryMapped<'a>> {
     data: Option<T>,
@@ -908,7 +908,7 @@ pub struct MappedOption<'a, T: MemoryMapped<'a>> {
     _marker: marker::PhantomData<&'a ()>,
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a, T: MemoryMapped<'a>> MappedOption<'a, T> {
     /// Returns `true` if the option is a [`Some`] value.
     pub fn is_some(&self) -> bool {
@@ -941,7 +941,7 @@ impl<'a, T: MemoryMapped<'a>> MappedOption<'a, T> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "libc")]
 impl<'a, T: MemoryMapped<'a>> MemoryMapped<'a> for MappedOption<'a, T> {
     fn new(map: &'a MemoryMap, offset: usize) -> io::Result<Self> {
         if offset >= map.len() {

--- a/src/serialize/tests.rs
+++ b/src/serialize/tests.rs
@@ -1,9 +1,12 @@
 use super::*;
+
+#[cfg(feature = "libc")]
 use std::fmt::Debug;
 use std::fs;
 
 //-----------------------------------------------------------------------------
 
+#[cfg(feature = "libc")]
 fn mapped_vector<P, T>(filename: P, correct: &Vec<T>, name: &str) where
     P: AsRef<Path>,
     T: Serializable + Debug + PartialEq
@@ -21,6 +24,7 @@ fn mapped_vector<P, T>(filename: P, correct: &Vec<T>, name: &str) where
     assert_eq!(*mapped, *correct, "Invalid mapped slice for {}", name);
 }
 
+#[cfg(feature = "libc")]
 fn mapped_bytes<P: AsRef<Path>>(filename: P, correct: &Vec<u8>, name: &str) {
     let map = MemoryMap::new(&filename, MappingMode::ReadOnly).unwrap();
     assert!(!map.is_empty(), "The file is empty for vector {}", name);
@@ -35,6 +39,7 @@ fn mapped_bytes<P: AsRef<Path>>(filename: P, correct: &Vec<u8>, name: &str) {
     assert_eq!(*mapped, *correct, "Invalid mapped slice for {}", name);
 }
 
+#[cfg(feature = "libc")]
 fn mapped_string<P: AsRef<Path>>(filename: P, correct: &String, name: &str) {
     let map = MemoryMap::new(&filename, MappingMode::ReadOnly).unwrap();
     assert!(!map.is_empty(), "The file is empty for string {}", name);
@@ -46,6 +51,7 @@ fn mapped_string<P: AsRef<Path>>(filename: P, correct: &String, name: &str) {
     assert_eq!(*mapped, *correct, "Invalid mapped string slice for {}", name);
 }
 
+#[cfg(feature = "libc")]
 fn mapped_option<P: AsRef<Path>>(filename: P, correct: &Option<Vec<u64>>, name: &str) {
     let map = MemoryMap::new(&filename, MappingMode::ReadOnly).unwrap();
     assert!(!map.is_empty(), "The file is empty for option {}", name);
@@ -74,11 +80,13 @@ fn serialize_usize() {
 fn serialize_vec_u64() {
     let empty: Vec<u64> = Vec::new();
     let filename = test(&empty, "empty-vec-u64", Some(1), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_vector(&filename, &empty, "empty-vec-u64");
     fs::remove_file(&filename).unwrap();
 
     let original: Vec<u64> = vec![1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89];
     let filename = test(&original, "non-empty-vec-u64", Some(1 + original.len()), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_vector(&filename, &original, "non-empty-vec-u64");
     fs::remove_file(&filename).unwrap();
 }
@@ -87,11 +95,13 @@ fn serialize_vec_u64() {
 fn serialize_vec_u64_u64() {
     let empty: Vec<(u64, u64)> = Vec::new();
     let filename = test(&empty, "empty-vec-u64-u64", Some(1), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_vector(&filename, &empty, "empty-vec-u64-u64");
     fs::remove_file(&filename).unwrap();
 
     let original: Vec<(u64, u64)> = vec![(1, 1), (2, 3), (5, 8), (13, 21), (34, 55), (89, 144)];
     let filename = test(&original, "non-empty-vec-u64-u64", Some(1 + 2 * original.len()), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_vector(&filename, &original, "non-empty-vec-u64-u64");
     fs::remove_file(&filename).unwrap();
 }
@@ -100,16 +110,19 @@ fn serialize_vec_u64_u64() {
 fn serialize_bytes() {
     let empty: Vec<u8> = Vec::new();
     let filename = test(&empty, "empty-vec-u8", Some(1), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_bytes(&filename, &empty, "empty-vec-u8");
     fs::remove_file(&filename).unwrap();
 
     let padded: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     let filename = test(&padded, "padded-vec-u8", Some(1 + bits::bytes_to_words(padded.len())), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_bytes(&filename, &padded, "padded-vec-u8");
     fs::remove_file(&filename).unwrap();
 
     let unpadded: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
     let filename = test(&unpadded, "unpadded-vec-u8", Some(1 + bits::bytes_to_words(unpadded.len())), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_bytes(&filename, &unpadded, "unpadded-vec-u8");
     fs::remove_file(&filename).unwrap();
 }
@@ -118,16 +131,19 @@ fn serialize_bytes() {
 fn serialize_string() {
     let empty = String::new();
     let filename = test(&empty, "empty-string", Some(1), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_string(&filename, &empty, "empty-string");
     fs::remove_file(&filename).unwrap();
 
     let padded = String::from("0123456789ABC");
     let filename = test(&padded, "padded-string", Some(1 + bits::bytes_to_words(padded.len())), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_string(&filename, &padded, "padded-string");
     fs::remove_file(&filename).unwrap();
 
     let unpadded = String::from("0123456789ABCDEF");
     let filename = test(&unpadded, "unpadded-string", Some(1 + bits::bytes_to_words(unpadded.len())), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_string(&filename, &unpadded, "unpadded-string");
     fs::remove_file(&filename).unwrap();
 }
@@ -136,11 +152,13 @@ fn serialize_string() {
 fn serialize_option() {
     let none: Option<Vec<u64>> = None;
     let filename = test(&none, "none-option", Some(1), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_option(&filename, &none, "none-option");
     fs::remove_file(&filename).unwrap();
 
     let some: Option<Vec<u64>> = Some(vec![1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89]);
     let filename = test(&some, "some-option", Some(1 + 1 + some.as_ref().unwrap().len()), false).unwrap();
+    #[cfg(feature = "libc")]
     mapped_option(&filename, &some, "some-option");
     fs::remove_file(&filename).unwrap();
 }

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -33,7 +33,8 @@
 
 use crate::bit_vector::BitVector;
 use crate::int_vector::IntVector;
-use crate::ops::{Vector, Access, BitVec, Rank, Select, PredSucc, SelectZero};
+use crate::ops::{Vector, Access};
+use crate::ops::{BitVec, Rank, Select, PredSucc, SelectZero, FullBitVec};
 use crate::raw_vector::{RawVector, AccessRaw};
 use crate::serialize::Serialize;
 use crate::bits;
@@ -1179,5 +1180,9 @@ impl Serialize for SparseVector {
         self.low.size_in_elements()
     }
 }
+
+//-----------------------------------------------------------------------------
+
+impl<'a> FullBitVec<'a> for SparseVector {}
 
 //-----------------------------------------------------------------------------

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -275,7 +275,7 @@ impl SparseVector {
 
     // Returns (run rank, one_iter past the run) for the run of 0s that contains
     // unset bit of the given rank.
-    fn find_zero_run(&self, rank: usize) -> (usize, OneIter) {
+    fn find_zero_run(&'_ self, rank: usize) -> (usize, OneIter<'_>) {
         let mut low = 0;
         let mut high = self.count_ones();
         let mut result = (0, self.one_iter());

--- a/src/sparse_vector.rs
+++ b/src/sparse_vector.rs
@@ -30,6 +30,7 @@
 //!
 //! We can also support multisets that contain duplicate values (in the integer array interpretation).
 //! Rank/select queries for unset bits do not work correctly with multisets.
+//! When a multiset is converted to other bitvector types, the result is a set.
 
 use crate::bit_vector::BitVector;
 use crate::int_vector::IntVector;
@@ -172,10 +173,15 @@ impl SparseVector {
     /// assert_eq!(sv.count_ones(), bv.count_ones());
     /// assert!(!sv.is_multiset());
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// May panic if the source bitvector is in an invalid state.
+    /// Will panic if the source is a `SparseVector` representing a multiset.
     pub fn copy_bit_vec<'a, T: BitVec<'a> + Select<'a>>(source: &'a T) -> Self {
         let mut builder = SparseBuilder::new(source.len(), source.count_ones()).unwrap();
         for (_, index) in source.one_iter() {
-            unsafe { builder.set_unchecked(index); }
+            builder.set(index);
         }
         SparseVector::try_from(builder).unwrap()
     }

--- a/src/support.rs
+++ b/src/support.rs
@@ -14,6 +14,12 @@ macro_rules! bitvector_conversion {
                 $target::copy_bit_vec(&source)
             }
         }
+
+        impl From<&$source> for $target {
+            fn from(source: &$source) -> Self {
+                $target::copy_bit_vec(source)
+            }
+        }
     };
 }
 

--- a/src/wavelet_matrix.rs
+++ b/src/wavelet_matrix.rs
@@ -2,11 +2,11 @@
 //!
 //! The wavelet matrix was first described in:
 //!
-//! > Claude, Navarro, Ordóñez: The wavelet matrix: An efficient wavelet tree for large alphabets.  
-//! > Information Systems, 2015.  
+//! > Claude, Navarro, Ordóñez: The wavelet matrix: An efficient wavelet tree for large alphabets.
+//! > Information Systems, 2015.
 //! > DOI: [10.1016/j.is.2014.06.002](https://doi.org/10.1016/j.is.2014.06.002)
 //!
-//! See [`wm_core`] for a low-level description.
+//! See [`wm_core`] for a low-level description and [`crate::rlwm`] for a run-length encoded variant.
 //! As in wavelet trees, access and rank queries proceed down from level `0`, while select queries go up from level `width - 1`.
 
 use crate::bit_vector::BitVector;
@@ -198,7 +198,7 @@ impl<'a> VectorIndex<'a> for WaveletMatrix<'a> {
         }
     }
 
-    fn value_of(iter: &Self::ValueIter) -> <Self as Vector>::Item {
+    fn value_of(&self, iter: &Self::ValueIter) -> <Self as Vector>::Item {
         iter.value
     }
 
@@ -267,7 +267,7 @@ impl<'a> Serialize for WaveletMatrix<'a> {
 ///
 /// // Iteration over values
 /// let mut iter = wm.value_iter(2);
-/// assert_eq!(WaveletMatrix::value_of(&iter), 2);
+/// assert_eq!(wm.value_of(&iter), 2);
 /// assert_eq!(iter.next(), Some((0, 5)));
 /// assert_eq!(iter.next(), Some((1, 9)));
 /// assert!(iter.next().is_none());
@@ -302,7 +302,7 @@ impl<'a> FusedIterator for ValueIter<'a> {}
 
 //-----------------------------------------------------------------------------
 
-/// [`WaveletMatrix`] transformed into an iterator.
+/// [`WaveletMatrix`] transformed into an iterator over its items.
 ///
 /// The type of `Item` is [`u64`].
 ///

--- a/src/wavelet_matrix.rs
+++ b/src/wavelet_matrix.rs
@@ -29,7 +29,7 @@ mod tests;
 /// An immutable integer vector supporting rank/select-type queries.
 ///
 /// Each item consists of the lowest 1 to 64 bits of a [`u64`] value, as specified by the width of the vector.
-/// The vector is represented using [`WMCore`].
+/// The vector is represented using [`WMCore`] with [`BitVector`] as the underlying bitvector type.
 /// There is also an [`IntVector`] storing the starting position of each possible item value after the reordering done by the core.
 /// Hence a `WaveletMatrix` should only be used when most values in `0..(1 << width)` are in use.
 /// The maximum length of the vector is approximately [`usize::MAX`] items.

--- a/src/wavelet_matrix/wm_core.rs
+++ b/src/wavelet_matrix/wm_core.rs
@@ -216,7 +216,7 @@ impl WMCore {
 
 //-----------------------------------------------------------------------------
 
-// FIXME: Separate construction from BitVector and RLVector.
+// FIXME: Separate construction for BitVector and RLVector.
 
 macro_rules! wm_core_from {
     ($t:ident) => {

--- a/src/wavelet_matrix/wm_core.rs
+++ b/src/wavelet_matrix/wm_core.rs
@@ -538,12 +538,7 @@ mod tests {
     }
 
     fn check_core_rl(core: &WMCore<'_, RLVector>, original: &[(u64, usize)]) {
-        let mut values: Vec<u64> = Vec::new();
-        for (value, len) in original.iter() {
-            for _ in 0..*len {
-                values.push(*value);
-            }
-        }
+        let values = internal::runs_to_values(original);
         check_core(core, &values);
 
         // map_down_with_run

--- a/src/wavelet_matrix/wm_core.rs
+++ b/src/wavelet_matrix/wm_core.rs
@@ -280,14 +280,14 @@ impl<'a> WMCore<'a, RLVector> {
     // Returns (new position, remaining run length).
     // Returns `None` if the index is out of bounds.
     fn map_up_one_with_run(&'a self, index: usize, level: usize) -> Option<(usize, usize)> {
-        self.levels[level].select_with_run(index - self.levels[level].count_zeros())
+        self.levels[level].select_run(index - self.levels[level].count_zeros())
     }
 
     // Maps the index from the next level with an unset bit.
     // Returns (new position, remaining run length).
     // Returns `None` if the index is out of bounds.
     fn map_up_zero_with_run(&'a self, index: usize, level: usize) -> Option<(usize, usize)> {
-        self.levels[level].select_zero_with_run(index)
+        self.levels[level].select_zero_run(index)
     }
 
     /// Maps up with the given value.
@@ -566,7 +566,7 @@ mod tests {
         let reordered = reordered_vector(&values);
         for i in 0..core.len() {
             let result = core.map_up_with_run(i, reordered[i]);
-            assert!(result.is_some(), "map_up_with_run returned None at {}", i); // FIXME: this fails
+            assert!(result.is_some(), "map_up_with_run returned None at {}", i);
             let (mapped, run_len) = result.unwrap();
             assert_eq!(values[mapped], reordered[i], "map_up_with_run returned a wrong mapped position at {}", i);
             let (down_index, _, down_run_len) = core.map_down_with_run(mapped).unwrap();

--- a/src/wavelet_matrix/wm_core.rs
+++ b/src/wavelet_matrix/wm_core.rs
@@ -323,7 +323,6 @@ impl<'a> WMCore<'a, RLVector> {
     }
 }
 
-
 //-----------------------------------------------------------------------------
 
 impl<'a, T: FullBitVec<'a>> Serialize for WMCore<'a, T> {

--- a/src/wavelet_matrix/wm_core.rs
+++ b/src/wavelet_matrix/wm_core.rs
@@ -79,11 +79,13 @@ pub struct WMCore<'a, T: FullBitVec<'a>> {
 
 impl<'a, T: FullBitVec<'a>> WMCore<'a, T> {
     /// Returns the length of each level in the structure.
+    #[inline]
     pub fn len(&self) -> usize {
         self.levels[0].len()
     }
 
     /// Returns the number of levels in the structure.
+    #[inline]
     pub fn width(&self) -> usize {
         self.levels.len()
     }

--- a/src/wavelet_matrix/wm_core.rs
+++ b/src/wavelet_matrix/wm_core.rs
@@ -31,7 +31,7 @@ use std::{cmp, io};
 
 //-----------------------------------------------------------------------------
 
-// FIXME Should this be generic over the bitvector type? How to handle construction?
+// FIXME Make generic over the bitvector type.
 /// A bidirectional mapping between the original vector and a stably sorted vector of the same items.
 ///
 /// Each item consists of the lowest 1 to 64 bits of a [`u64`] value, as specified by the width of the vector.
@@ -46,7 +46,7 @@ use std::{cmp, io};
 /// ```
 /// use simple_sds::wavelet_matrix::wm_core::WMCore;
 ///
-/// // Construction
+/// // Source data
 /// let source: Vec<u64> = vec![1, 0, 3, 1, 1, 2, 4, 5, 1, 2, 1, 7, 0, 1];
 /// let mut reordered: Vec<u64> = source.clone();
 /// reordered.sort_by_key(|x| x.reverse_bits());
@@ -215,6 +215,8 @@ impl WMCore {
 }
 
 //-----------------------------------------------------------------------------
+
+// FIXME: Separate construction from BitVector and RLVector.
 
 macro_rules! wm_core_from {
     ($t:ident) => {

--- a/src/wavelet_matrix/wm_core.rs
+++ b/src/wavelet_matrix/wm_core.rs
@@ -84,6 +84,14 @@ impl<'a, T: FullBitVec<'a>> WMCore<'a, T> {
         self.levels[0].len()
     }
 
+    /// Returns `true` if the structure is empty.
+    ///
+    /// Keeps Clippy happy.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns the number of levels in the structure.
     #[inline]
     pub fn width(&self) -> usize {


### PR DESCRIPTION
This PR adds `RLWM`: a wavelet matrix using run-length encoded bitvectors. It provides some additional functionality for querying / accessing / iterating over entire runs. To enable that, `RLVector` also has `rank`, `select`, and `select_zero` variants that return right-maximal runs.

`WMCore` is now generic over bitvector types. To make this practical, there is now a `FullBitVec` marker trait that requires all other traits a bitvector should implement.

`libc` is now an optional feature that enables memory-mapping. It is enabled by default and required by binaries. When disabled, Simple-SDS should work on wasm64.

Also updates some dependencies and switches to Rust 2024.