### PR TITLE
inverse_select for bitvectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,32 +17,25 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
   * Supports `rank()`, `inverse_select()`, `select()`, `predecessor()`, and `successor()` with each item value.
   * Iterators over all items and over items with a specified value.
   * Implemented using a `BitVector` for each level.
+* `RLWM`: A run-length encoded immutable vector of fixed-width integers.
+  * Supports `rank()`, `inverse_select()`, `select()`, `predecessor()`, and `successor()` with each item value.
+  * Iterators over all items and over items with a specified value, with an option to iterate over runs of items.
+  * Implemented using a `RLVector` for each level.
 
 ### Bitvectors
 
 * `BitVector`: A plain immutable bitvector.
-  * Supports `rank()`, `rank_zero()`, `select()`, `select_zero()`, `predecessor()`, and `successor()` queries using optional support structures.
+  * Supports `rank()`, `rank_zero()`, `inverse_select()`, `select()`, `select_zero()`, `predecessor()`, and `successor()` queries using optional support structures.
   * Iterators over set bits, unset bits, and all bits.
   * Implemented on top of `RawVector`.
 * `RLVector`: A run-length encoded bitvector.
-  * Supports `rank()`, `rank_zero()`, `select()`, `select_zero()`, `predecessor()`, and `successor()` queries.
+  * Supports `rank()`, `rank_zero()`, `inverse_select()`, `select()`, `select_zero()`, `predecessor()`, and `successor()` queries.
   * Iterators over set bits and all bits.
   * Space-efficient construction with `RLBuilder`.
 * `SparseVector`: An Elias-Fano encoded bitvector.
-  * Supports `rank()`, `rank_zero()`, `select()`, `select_zero()`, `predecessor()`, and `successor()` queries .
+  * Supports `rank()`, `rank_zero()`, `inverse_select()`, `select()`, `select_zero()`, `predecessor()`, and `successor()` queries .
   * Iterators over set bits and all bits.
   * Space-efficient construction with `SparseBuilder`.
-
-## Planned functionality
-
-### Integer vectors
-
-* Mutable memory-mapped vectors.
-
-### Bitvectors
-
-* Versions of `predecessor()` and `successor()` that return values instead of iterators?
-* Slice-like functionality based on iterators?
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ As the focus is on (relative) simplicity, ugly low-level optimizations are gener
 * The included `.cargo/config.toml` sets the target CPU to `native`.
 * This crate is designed for the x86_64 architecture with the BMI2 instruction set (Intel Haswell / AMD Excavator or later). Some operations may be slow without the POPCNT, LZCNT, TZCNT, and PDEP instructions.
 * 64-bit ARM is also supported.
-* Unix-like operating system is required for `mmap()`.
+* Unix-like operating system is required for `mmap()`, which is enabled with feature `libc`.
 * Things may not work if the system is not little-endian or if `usize` is not 64-bit.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,7 @@
 
 * `RLVector`: Run-length encoded bitvector similar to the one in RLCSA.
 * `FullBitVec`: A marker trait indicating a fully functional bitvector.
+* `Rank::inverse_select` method for bitvectors.
 * Consistent conversions between bitvector types:
   * `From` trait between any two bitvector types from both values and references.
   * Associated function `copy_bit_vec` for copying from a type that implements `Select`.

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1003,13 +1003,15 @@ pub trait Rank<'a>: BitVec<'a> {
         if index >= self.len() {
             return None;
         }
+        // We may get better instruction-level parallelism by computing `rank`
+        // unconditionally instead of calling `rank_zero` when the bit is unset.
         let bit = self.get(index);
-        let rank = if bit {
-            self.rank(index)
+        let rank = self.rank(index);
+        if bit {
+            Some((rank, bit))
         } else {
-            self.rank_zero(index)
-        };
-        Some((rank, bit))
+            Some((index - rank, bit))
+        }
     }
 
 }

--- a/src/rl_vector.rs
+++ b/src/rl_vector.rs
@@ -790,6 +790,28 @@ impl<'a> Rank<'a> for RLVector {
 
         iter.rank()
     }
+
+    fn inverse_select(&self, index: usize) -> Option<(usize, bool)> {
+        if index >= self.len() {
+            return None;
+        }
+
+        let mut iter = self.iter_for_bit(index);
+        while let Some((start, len)) = iter.next() {
+            if start > index {
+                // The bit is unset.
+                let rank = iter.rank() - len;
+                return Some((index - rank, false));
+            }
+            if start + len > index {
+                // The bit is set.
+                return Some((iter.rank_at(index), true));
+            }
+        }
+
+        // The bit is unset in the final run.
+        Some((index - iter.rank(), false))
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/rlwm.rs
+++ b/src/rlwm.rs
@@ -233,7 +233,7 @@ impl<'a> VectorIndex<'a> for RLWM<'a> {
         }
     }
 
-    // TODO: implement predecessor/successor using the same functionality in RLVector?
+    // TODO: override default predecessor/successor using the same functionality in RLVector?
 }
 
 impl <'a> RLWM<'a> {

--- a/src/rlwm.rs
+++ b/src/rlwm.rs
@@ -41,11 +41,6 @@ mod tests;
 /// * Queries and operations: [`VectorIndex`]
 /// * Serialization: [`Serialize`]
 ///
-/// Overridden default implementations:
-/// * [`VectorIndex::contains`] has a simple constant-time implementation.
-/// * [`VectorIndex::inverse_select`] is effectively the same as [`Access::get`].
-/// * [`Access::iter`] returns a more efficient iterator that accesses the vector one run at a time.
-///
 /// Both iterators ([`AccessIter`] and [`ValueIter`]) support iterating over the runs using `next_run`.
 ///
 /// # Examples

--- a/src/wavelet_matrix.rs
+++ b/src/wavelet_matrix.rs
@@ -43,10 +43,6 @@ mod tests;
 /// * Queries and operations: [`VectorIndex`]
 /// * Serialization: [`Serialize`]
 ///
-/// Overridden default implementations:
-/// * [`VectorIndex::contains`] has a simple constant-time implementation.
-/// * [`VectorIndex::inverse_select`] is effectively the same as [`Access::get`].
-///
 /// # Examples
 ///
 /// ```

--- a/src/wavelet_matrix/wm_core.rs
+++ b/src/wavelet_matrix/wm_core.rs
@@ -103,7 +103,6 @@ impl<'a, T: FullBitVec<'a>> WMCore<'a, T> {
         self.levels.len()
     }
 
-    // TODO: this should use inverse_select when it's implemented
     /// Maps the item at the given position down.
     ///
     /// Returns the position of the item in the reordered vector and the value of the item, or [`None`] if the position is invalid.
@@ -115,11 +114,12 @@ impl<'a, T: FullBitVec<'a>> WMCore<'a, T> {
         let mut index = index;
         let mut value = 0;
         for level in 0..self.width() {
-            if self.levels[level].get(index) {
-                index = self.map_down_one(index, level);
+            let (rank, bit) = self.levels[level].inverse_select(index)?;
+            if bit {
+                index = self.levels[level].count_zeros() + rank;
                 value += self.bit_value(level);
             } else {
-                index = self.map_down_zero(index, level);
+                index = rank;
             }
         }
 


### PR DESCRIPTION
`Rank::inverse_select` for bitvectors. As the name implies, `inverse_select(index)` returns `(rank, bit)` such that either `select(rank) == index` or `select_zero(rank) == index`, depending on `bit`. This can also be understood as computing the rank for the item at index `index`.

Trait `Rank` provides a default implementation, which is appropriate for plain bitvectors, where `BitVec::get` is a trivial operation. `SparseVector` and `RLVector` have custom implementations. Compressed bitvectors in general should override the default implementation, as the query can usually be done as a single operation.

`WMCore::map_down` now uses `Rank::inverse_select`. This speeds up `Access::get` and `VectorIndex::inverse_select` for `WaveletMatrix` and particularly for `RLWM`.