### PR TITLE
Don't pass uninitialized memory to Read::read_exact

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -240,7 +240,7 @@ impl<V: Serializable> Serialize for Vec<V> {
 
     fn load<T: Read>(reader: &mut T) -> io::Result<Self> {
         let size = usize::load(reader)?;
-        let mut value: Vec<V> = Vec::with_capacity(size);
+        let mut value: Vec<V> = vec![0u8; size];
 
         unsafe {
             let buf: &mut [u8] = slice::from_raw_parts_mut(value.as_mut_ptr() as *mut u8, size * mem::size_of::<V>());


### PR DESCRIPTION
This is UB according to [`Read::read()` documentation](https://doc.rust-lang.org/stable/std/io/trait.Read.html#tymethod.read).

> Correspondingly, however, callers of this method in unsafe code must not assume any guarantees about how the implementation uses buf. The trait is safe to implement, so it is possible that the code that’s supposed to write to the buffer might also read from it. It is your responsibility to make sure that buf is initialized before calling read. Calling read with an uninitialized buf (of the kind one obtains via [MaybeUninit<T>](https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html)) is not safe, and can lead to undefined behavior.


Note that currently even without the `read_exact` this is UB since it is UB to construct an `&mut [u8]` to uninitialized memory. The opsem group is discussing changing this, though (https://github.com/rust-lang/unsafe-code-guidelines/issues/414).