### PR TITLE
Check mmap result against MAP_FAILED

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -596,7 +596,7 @@ impl MemoryMap {
             MappingMode::Mutable => libc::PROT_READ | libc::PROT_WRITE,
         };
         let ptr = unsafe { libc::mmap(ptr::null_mut(), len, prot, libc::MAP_SHARED, file.as_raw_fd(), 0) };
-        if ptr.is_null() {
+        if ptr.is_null() || ptr == libc::MAP_FAILED {
             return Err(Error::other("Memory mapping failed"));
         }
 


### PR DESCRIPTION
mmap doesn't return null on failure: https://man7.org/linux/man-pages/man2/mmap.2.html#RETURN_VALUE