### PR TITLE
Avoid integer overflow in IntVector::load

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,7 @@
   * Memory-mapped structures check for `mmap()` failure correctly.
   * Memory-mapped structures are unmapped correctly.
   * Correct out-of-bounds checks when creating a `MappedSlice`.
+  * `IntVector` length validation no longer overflows during deserialization.
   * `Serialize` implementation for a `Vec` of `Serializable` no longer uses uninitialized memory.
 
 ## Simple-SDS 0.4.2 (2026-08-24)

--- a/src/int_vector.rs
+++ b/src/int_vector.rs
@@ -304,7 +304,7 @@ impl Serialize for IntVector {
             return Err(Error::new(ErrorKind::InvalidData, "Integer width must be 1 to 64 bits"));
         }
         let data = RawVector::load(reader)?;
-        if len * width != data.len() {
+        if len.checked_mul(width) != Some(data.len()) {
             Err(Error::new(ErrorKind::InvalidData, "Data length does not match len * width"))
         }
         else {

--- a/src/int_vector/tests.rs
+++ b/src/int_vector/tests.rs
@@ -203,6 +203,34 @@ fn invalid_data() {
     fs::remove_file(&filename).unwrap();
 }
 
+#[test]
+fn overflow_data() {
+    // Test cases where len * width overflows usize:
+    // 1. len = usize::MAX, width = 2: overflows usize (panics on unpatched code in debug mode).
+    // 2. len = 1 << (usize::BITS - 1), width = 2: wraps to 0 in release mode, matching
+    //    data.len() == 0 and causing unpatched code to accept corrupted data.
+    let test_cases: [(usize, usize); 2] = [
+        (usize::MAX, 2),
+        (1usize << (usize::BITS - 1), 2),
+    ];
+    for (len, width) in test_cases {
+        let filename = serialize::temp_file_name("int-vector-overflow-data");
+        let mut options = OpenOptions::new();
+        let mut file = options.create(true).write(true).truncate(true).open(&filename).unwrap();
+
+        let data = RawVector::new();
+        len.serialize(&mut file).unwrap();
+        width.serialize(&mut file).unwrap();
+        data.serialize(&mut file).unwrap();
+        drop(file);
+
+        let result: io::Result<IntVector> = serialize::load_from(&filename);
+        assert_eq!(result.map_err(|e| e.kind()), Err(ErrorKind::InvalidData), "Expected ErrorKind::InvalidData");
+
+        fs::remove_file(&filename).unwrap();
+    }
+}
+
 //-----------------------------------------------------------------------------
 
 #[test]


### PR DESCRIPTION
Follow-up to #24.

`IntVector::load` computed `len * width` without checking for overflow. With a corrupted or crafted file, this panics in debug builds and wraps in release builds, allowing an `IntVector` to be constructed whose `len` does not match its data.

It now uses `checked_mul`, with a test covering both debug panic and release-mode silent wrapping.